### PR TITLE
Changes for OpenShift deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -22,12 +22,13 @@ PROJECT_ROOT = os.path.abspath(
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '8flmz)c9i!o&f1-moi5-p&9ak4r9=ck$3!0y1@%34p^(6i*^_9'
+SECRET_KEY = os.environ.get('WEB_DJANGO_SECRET_KEY',
+                            '8flmz)c9i!o&f1-moi5-p&9ak4r9=ck$3!0y1@%34p^(6i*^_9')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ["test.diamond.ac.uk"]
+ALLOWED_HOSTS = ["*"]
 
 REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
@@ -37,16 +38,16 @@ REST_FRAMEWORK = {
 
 import requests
 ########## ALLOWED_HOSTS
-from requests.exceptions import ConnectionError
-
-url = "http://169.254.169.254/latest/meta-data/public-ipv4"
-try:
-    r = requests.get(url)
-    instance_ip = r.text
-    ALLOWED_HOSTS += [instance_ip]
-except ConnectionError:
-    error_msg = "You can only run production settings on an AWS EC2 instance"
-    # raise ImproperlyConfigured(error_msg)
+#from requests.exceptions import ConnectionError
+#
+#url = "http://169.254.169.254/latest/meta-data/public-ipv4"
+#try:
+#    r = requests.get(url)
+#    instance_ip = r.text
+#    ALLOWED_HOSTS += [instance_ip]
+#except ConnectionError:
+#    error_msg = "You can only run production settings on an AWS EC2 instance"
+#    # raise ImproperlyConfigured(error_msg)
 ########## END ALLOWED_HOSTS
 
 

--- a/loader.py
+++ b/loader.py
@@ -6,8 +6,7 @@ if __name__ == "__main__":
     django.setup()
     from loader.loaders import load_from_dir
     from loader.loaders import analyse_target
-    targets_to_load = ["CAMK1DA","DCLRE1AA","DCP2B","FALZA","MURD","NUDT21A","NUDT22A","NUDT7A",
-                       "PARP14A","PHIPA","SETDB1","SHMT2A","HAO1A"]
+    targets_to_load = ["CAMK1DA", "HAO1A", "MURD", "PARP14A", "PHIPA", "SETDB1"]
     for t in targets_to_load:
         load_from_dir(t,"/code/media/"+t)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pickleshare==0.7.4
 Pillow==5.0.0
 pprint==0.1
 prompt-toolkit==1.0.15
-psycopg2==2.7.4
+psycopg2-binary==2.7.4
 ptyprocess==0.5.2
 pyasn1==0.1.9
 pycrypto==2.6.1


### PR DESCRIPTION
Changes relate to: -

- **settings.py** to extract Django `SECRET_KEY` from an optional env-variable (set by the OpenShift templates). ALLOWED_HOSTS opened up and disabled
- **loader.py** has a smaller dataset to minimise resultant image size.
- **requirements.txt** to use `psycopg2-binary` as `psycopg2` is listed as deprecated