### PR TITLE
Update to PyCryptodome

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ prompt-toolkit==1.0.15
 psycopg2-binary==2.7.4
 ptyprocess==0.5.2
 pyasn1==0.1.9
-pycrypto==2.6.1
+pycryptodome==3.6.6
 Pygments==2.2.0
 python-cas==1.2.0
 pytz==2018.3


### PR DESCRIPTION
Due to this - https://nvd.nist.gov/vuln/detail/CVE-2018-6594 meaning pycrypto is no longer useful
and the fix suggested here:
https://github.com/oduwsdl/ipwb/issues/303

I move to this;
https://pypi.org/project/pycryptodome/
