### PR TITLE
Issue 216 sentry dns

### DIFF
--- a/django_nginx.conf
+++ b/django_nginx.conf
@@ -32,7 +32,11 @@ server {
     }
     location / {
         include proxy_params;
-        proxy_pass http://unix:/code/django_app.sock;
+#        proxy_pass http://unix:/code/django_app.sock;
+        # This fixes a download redirect problem found using Chrome.
+        # This solution: https://djangodeployment.com/2017/01/24/fix-djangos-https-redirects-nginx/
+        proxy_redirect off;
+        proxy_set_header X-Forwarded-Proto $scheme;
         uwsgi_read_timeout 300s;
     }
 

--- a/django_nginx.conf
+++ b/django_nginx.conf
@@ -2,6 +2,11 @@ server {
     client_max_body_size 0;
     listen 80;
     server_name ~^(.+)$;
+
+    # L2 - Test
+    include proxy_params;
+    proxy_redirect off;
+
     location = /favicon.ico { access_log off; log_not_found off; }
     location /static/ {
         root /code;
@@ -31,14 +36,7 @@ server {
         internal;
     }
     location / {
-        include proxy_params;
         proxy_pass http://unix:/code/django_app.sock;
-        # This fixes a download redirect problem found using Chrome.
-        # This solution: https://djangodeployment.com/2017/01/24/fix-djangos-https-redirects-nginx/
-        proxy_redirect off;
-        proxy_set_header X-Forwarded-Proto $scheme;
         uwsgi_read_timeout 300s;
     }
-
-
 }

--- a/django_nginx.conf
+++ b/django_nginx.conf
@@ -32,7 +32,7 @@ server {
     }
     location / {
         include proxy_params;
-#        proxy_pass http://unix:/code/django_app.sock;
+        proxy_pass http://unix:/code/django_app.sock;
         # This fixes a download redirect problem found using Chrome.
         # This solution: https://djangodeployment.com/2017/01/24/fix-djangos-https-redirects-nginx/
         proxy_redirect off;

--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -32,10 +32,12 @@ PROPOSAL_REQUIRED = True
 # Should always be True on production.
 AUTHENTICATE_UPLOAD = True
 
-if DEBUG == False:
+# This is set on AWX when the fragalysis-stack is rebuilt.
+SENTRY_DNS = os.environ.get("FRAGALYSIS_BACKEND_SENTRY_DNS")
+if DEBUG is False and SENTRY_DNS:
     # By default only call sentry in staging/production
     sentry_sdk.init(
-        dsn="https://27fa0675f555431aa02ca552e93d8cfb@o194333.ingest.sentry.io/1298290",
+        dsn=SENTRY_DNS,
         integrations=[DjangoIntegration(), CeleryIntegration(), RedisIntegration()],
 
         # If you wish to associate users to errors (assuming you are using

--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -18,7 +18,7 @@ from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 # These flags are used in the upload_tset form as follows.
 # Proposal Supported | Proposal Required | Proposal / View fields

--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -18,7 +18,7 @@ from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
 # These flags are used in the upload_tset form as follows.
 # Proposal Supported | Proposal Required | Proposal / View fields
@@ -33,7 +33,7 @@ PROPOSAL_REQUIRED = True
 AUTHENTICATE_UPLOAD = True
 
 if DEBUG == False:
-# By default only call sentry in staging/production
+    # By default only call sentry in staging/production
     sentry_sdk.init(
         dsn="https://27fa0675f555431aa02ca552e93d8cfb@o194333.ingest.sentry.io/1298290",
         integrations=[DjangoIntegration(), CeleryIntegration(), RedisIntegration()],

--- a/viewer/serializers.py
+++ b/viewer/serializers.py
@@ -53,9 +53,11 @@ class TargetSerializer(serializers.ModelSerializer):
     def get_zip_archive(self, obj):
         request = self.context["request"]
         # This is to map links to HTTPS to avoid Mixed Content warnings from Chrome browsers
-        # Note that this link will not work on local
         # SECURE_PROXY_SSL_HEADER is referenced because it is used in redirecting URLs - if it is changed
         # it make affect this code.
+        # Using relative links will probably also work, but This workaround allows both the 'download structures'
+        # button and the DRF API call to work.
+        # Note that this link will not work on local
         https_host = settings.SECURE_PROXY_SSL_HEADER[1]+'://'+request.get_host()
         return urljoin(https_host, obj.zip_archive.url)
 


### PR DESCRIPTION
Fix to make sentry dns an environment variable that can be set when launching the Fragalysis Stack from AWX.
Linked to fragalysis backend issue: https://github.com/xchem/fragalysis-backend/issues/216
