### PR TITLE
Fix so that docker-compose.test.yml will pass.

### DIFF
--- a/viewer/serializers.py
+++ b/viewer/serializers.py
@@ -53,20 +53,27 @@ class TargetSerializer(serializers.ModelSerializer):
     def get_zip_archive(self, obj):
         request = self.context["request"]
         # This is to map links to HTTPS to avoid Mixed Content warnings from Chrome browsers
-        # SECURE_PROXY_SSL_HEADER is referenced because it is used in redirecting URLs - if it is changed
-        # it make affect this code.
-        # Using relative links will probably also work, but This workaround allows both the 'download structures'
-        # button and the DRF API call to work.
+        # SECURE_PROXY_SSL_HEADER is referenced because it is used in redirecting URLs - if
+        # it is changed it may affect this code.
+        # Using relative links will probably also work, but This workaround allows both the
+        # 'download structures' button and the DRF API call to work.
+        # The if-check is because the filefield in target has null=True.
         # Note that this link will not work on local
-        https_host = settings.SECURE_PROXY_SSL_HEADER[1]+'://'+request.get_host()
-        return urljoin(https_host, obj.zip_archive.url)
+        https_host = settings.SECURE_PROXY_SSL_HEADER[1] + '://' + request.get_host()
+        if hasattr(obj, 'zip_archive') and obj.zip_archive.name:
+            return urljoin(https_host, obj.zip_archive.url)
+        else:
+            return
 
     def get_metadata(self, obj):
         request = self.context["request"]
         # This is to map links to HTTPS to avoid Mixed Content warnings from Chrome browsers
-        # Note that this link will not work on local - see above.
-        https_host = settings.SECURE_PROXY_SSL_HEADER[1]+'://'+request.get_host()
-        return urljoin(https_host, obj.metadata.url)
+        # See above for details.
+        https_host = settings.SECURE_PROXY_SSL_HEADER[1] + '://' + request.get_host()
+        if hasattr(obj, 'metadata') and obj.metadata.name:
+            return urljoin(https_host, obj.metadata.url)
+        else:
+            return
 
     class Meta:
         model = Target


### PR DESCRIPTION
Fix so that docker-compose.test.yml will pass.
This was actually caused by the http to https fix.

The script tested the target API when no targets were loaded (so the code that created the https link could not get a url from a filefield was not actually connected to a target).
