### PR TITLE
On logon, search for username if no users found for email

### DIFF
--- a/fragalysis/auth.py
+++ b/fragalysis/auth.py
@@ -14,6 +14,23 @@ class KeycloakOIDCAuthenticationBackend(OIDCAuthenticationBackend):
         user.save()
         return user
 
+    def filter_users_by_claims(self, claims):
+        """ Return all users matching the specified email.
+            If nothing found matching the email, then try the username
+        """
+        email = claims.get('email')
+        preferred_username = claims.get('preferred_username')
+
+        if not email:
+            return self.UserModel.objects.none()
+        users = self.UserModel.objects.filter(email__iexact=email)
+
+        if len(users) < 1:
+            if not preferred_username:
+                return self.UserModel.objects.none()
+            users = self.UserModel.objects.filter(username__iexact=preferred_username)
+        return users
+
     def update_user(self, user, claims):
         user.first_name = claims.get('given_name', '')
         user.last_name = claims.get('family_name', '')


### PR DESCRIPTION
Keycloak authentication will now search for username if it doesn't find the email when logging on.
This should allow current users to logon with the same user-id/Fed-id using CAS via Keycloak.