### PR TITLE
Changes to send back url when posting to an existing category/topic 

### DIFF
--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -19,7 +19,7 @@ from sentry_sdk.integrations.redis import RedisIntegration
 from sentry_sdk.integrations.excepthook import ExcepthookIntegration
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
 # These flags are used in the upload_tset form as follows.
 # Proposal Supported | Proposal Required | Proposal / View fields
@@ -322,9 +322,17 @@ if EMAIL_HOST_USER:
 # Discourse settings for API calls to Discourse Platform
 DISCOURSE_PARENT_CATEGORY = 'Fragalysis targets'
 DISCOURSE_USER = 'fragalysis'
-DISCOURSE_HOST = os.environ.get('DISCOURSE_HOST', 'https://discourse.xchem-dev.diamond.ac.uk/')
-# Note that this can be obtained from discourse for the dev environment.
+DISCOURSE_HOST = os.environ.get('DISCOURSE_HOST', 'https://discourse.xchem-dev.diamond.ac.uk')
+# Note that this can be obtained from discourse for the desired environment.
 DISCOURSE_API_KEY = os.environ.get("DISCOURSE_API_KEY")
+
+# This suffix can be set to that the different development environments posting to the same Discourse
+# server can "automatically" generate different category/post titles - hopefully reducing confusion.
+# It will be appended at category or post-title, e.g. "Mpro-duncan", "Mpro-staging" etc.
+# Note that it is for dev systems. It is not required on production because production will have a
+# dedicated Discourse server.
+DISCOURSE_DEV_POST_SUFFIX = os.environ.get("DISCOURSE_DEV_POST_SUFFIX", '')
+
 
 # This is set up for logging in development probably good to switch off in staging/prod as sentry should deal with
 # errors. Hence connection to DEBUG flag.

--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -19,7 +19,7 @@ from sentry_sdk.integrations.redis import RedisIntegration
 from sentry_sdk.integrations.excepthook import ExcepthookIntegration
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 # These flags are used in the upload_tset form as follows.
 # Proposal Supported | Proposal Required | Proposal / View fields

--- a/viewer/discourse.py
+++ b/viewer/discourse.py
@@ -12,10 +12,23 @@ def get_user(client, username):
     """Call discourse API users to retreive user by username.
     """
     logger.info('+ discourse.get_user')
+    error = False
+    error_message = ''
+    user = 0
 
-    user = client.user(username)
+    try:
+        user = client.user(username)
+    except Exception as e:
+        # User is not known in Discourse or there is a failure accessing Discourse.
+        logger.error('discourse.get_user', 'get_user', exc_info=e)
+        error = True
+        error_message = 'Error validating user in Discourse. If this is your first post please log on to ' \
+                        'Discourse once to create a User. URL is: ' + settings.DISCOURSE_HOST
+    else:
+        user = user['id']
+
     logger.info('- discourse.get_user')
-    return user['id']
+    return error, error_message, user
 
 
 def create_category(client, category_name, parent_name, category_colour='0088CC', category_text_colour='FFFFFF'):
@@ -33,7 +46,10 @@ def create_category(client, category_name, parent_name, category_colour='0088CC'
 def process_category (category_details):
     """Check category is present in Table - If not create it in Discourse and store the id returned..
     """
-    post_url =''
+
+    # DISCOURSE_DEV_POST_SUFFIX is used to differentiate the same target name from different dev systems in Discourse
+    # It is not intended to be used for production when there is a dedicated Discourse.
+    category_name = category_details['category_name'] + settings.DISCOURSE_DEV_POST_SUFFIX
 
     # Create Discourse client for fragalysis user
     client = DiscourseClient(
@@ -42,50 +58,83 @@ def process_category (category_details):
         api_key=settings.DISCOURSE_API_KEY)
 
     try:
-        category = DiscourseCategory.objects.get(category_name=category_details['category_name'])
+        category = DiscourseCategory.objects.get(category_name=category_name)
         category_id = category.discourse_category_id
+        post_url = os.path.join(settings.DISCOURSE_HOST, 'c', str(category_id))
     except DiscourseCategory.DoesNotExist:
-        category_id, post_url = create_category(client, category_details['category_name'],
+        category_id, post_url = create_category(client, category_name,
                                                 category_details['parent_name'],
                                                 category_details['category_colour'],
                                                 category_details['category_text_colour'])
-        DiscourseCategory.objects.create(category_name=category_details['category_name'],
+        DiscourseCategory.objects.create(category_name=category_name,
                                          discourse_category_id=category_id)
     return category_id, post_url
 
 
-def create_post(client, content, tags=None, title=None, category_id=None, topic_id=None):
+def create_post(user, post_details, category_id=None, topic_id=None):
     """Call discourse API posts.json to create a new Topic or Post within a topic
     """
+
     logger.info('+ discourse.create_post')
+    if not user.is_authenticated:
+        return True, 'Please logon to Post to Discourse', 0, ''
+
+    # Create Discourse client for user
+    client = DiscourseClient(
+        settings.DISCOURSE_HOST,
+        api_username=user.username,
+        api_key=settings.DISCOURSE_API_KEY)
+
+    # Check user is present in Discourse
+    error, error_message, user_id = get_user(client, user.username)
+    if user_id == 0:
+        return error, error_message, user_id
+
+    title = post_details['title']
+    content = post_details['content']
+    tags = post_details['tags']
+
     if tags is None:
         tags = []
+
+    if len(content) < 20:
+        return True, 'Content must be more than 20 characters long in Discourse', 0, ''
 
     post = client.create_post(content, category_id, topic_id, title, tags)
     # posts url = / t / {topic_id} / {post_number}
     post_url = os.path.join(settings.DISCOURSE_HOST, 't',  str(post['topic_id']),  str(post['post_number']))
     logger.info('- discourse.create_post')
 
-    return post['topic_id'], post_url
+    return error, error_message, post['topic_id'], post_url
 
 
-def process_post(client, category_id, post_details, user):
+def process_post(category_id, post_details, user):
     """Check topic is present in Discourse. IF exists then post, otherwise create new topic for category
     """
+    error = False
+    error_message = ''
+
+    # DISCOURSE_DEV_POST_SUFFIX is used to differentiate the same target name from different dev systems in Discourse
+    # It is not intended to be used for production when there is a dedicated Discourse.
+    post_details['title'] = post_details['title'] + settings.DISCOURSE_DEV_POST_SUFFIX
 
     try:
         topic = DiscourseTopic.objects.get(topic_title=post_details['title'])
         topic_id = topic.discourse_topic_id
-        # Create post for topic
-        null_id, post_url = create_post(client, post_details['content'], post_details['tags'], topic_id=topic_id)
+        if post_details['content'] == '':
+            # No content - Return the URL for the topic
+            post_url = os.path.join(settings.DISCOURSE_HOST, 't', str(topic_id))
+        else:
+            # Create post for topic
+            error, error_message, null_id, post_url = create_post(user, post_details, topic_id=topic_id)
     except DiscourseTopic.DoesNotExist:
         # Create Topic for Category
-        topic_id, post_url = create_post(client, post_details['content'], post_details['tags'],
-                                         title=post_details['title'], category_id=category_id)
-        DiscourseTopic.objects.create(topic_title=post_details['title'],
-                                      author=user,
-                                      discourse_topic_id=topic_id)
-    return topic_id, post_url
+        error, error_message, topic_id, post_url = create_post(user, post_details, category_id=category_id)
+        if not error:
+            DiscourseTopic.objects.create(topic_title=post_details['title'],
+                                          author=user,
+                                          discourse_topic_id=topic_id)
+    return error, error_message, topic_id, post_url
 
 
 def topic_posts(client, topic_id):
@@ -114,14 +163,13 @@ def create_discourse_post(user, category_details=None, post_details=None):
 
     logger.info('+ discourse.create_discourse_post')
     error = False
+    error_message = ''
+
     post_url = ''
     if category_details is None and post_details is None:
         # Nothing to post
-        return True
-
-    if user is None:
-        # User is not logger on
-        return True
+        error_message = 'Please supply either category or post details'
+        return True, post_url, error_message
 
     category_id = 0
 
@@ -131,20 +179,10 @@ def create_discourse_post(user, category_details=None, post_details=None):
 
     # If post details exist then create the post
     if post_details:
-        # Create Discourse client for user
-        client = DiscourseClient(
-            settings.DISCOURSE_HOST,
-            api_username=user.username,
-            api_key=settings.DISCOURSE_API_KEY)
-
-        # Check user is present in Discourse
-        user_id = get_user(client, user.username)
-        if user_id == 0:
-            return True
-        topic_id, post_url = process_post(client, category_id, post_details, user)
+        error, error_message, topic_id, post_url = process_post(category_id, post_details, user)
 
     logger.info('- discourse.create_discourse_post')
-    return error, post_url
+    return error, post_url, error_message
 
 
 def list_discourse_posts_for_topic(topic_title):

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -2346,11 +2346,11 @@ class DiscoursePostView(viewsets.ViewSet):
                             'content': data['post_content'],
                             'tags': json.loads(data['post_tags'])}
 
-        error, post_url = create_discourse_post(request.user, category_details, post_details)
+        error, post_url, error_message = create_discourse_post(request.user, category_details, post_details)
 
         logger.info('- DiscoursePostView.post')
         if error:
-            return Response({"message": "Error Creating Post"})
+            return Response({"message": error_message})
         else:
             return Response({"Post url": post_url})
 


### PR DESCRIPTION
… rather than error.
This was requested for the Frontend.

Also add new environment variable - DISCOURSE_DEV_POST_SUFFIX.
This is optional but is used to identify the calling Fragalysis in the situation where several Fragalysis instances are calling one Discourse instance to reduce the chance of duplicate categories/topics being created. 

Also fixes a setting which was causing an error validating the user with Discourse and adds some other error checking to match the usage requirements from the Frontend.

This is a low risk PR - it only affects the new code for Discourse. 
