### PR TITLE
User present on discourse

### DIFF
--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -322,7 +322,7 @@ if EMAIL_HOST_USER:
 # Discourse settings for API calls to Discourse Platform
 DISCOURSE_PARENT_CATEGORY = 'Fragalysis targets'
 DISCOURSE_USER = 'fragalysis'
-DISCOURSE_HOST = os.environ.get('DISCOURSE_HOST', 'https://discourse.xchem-dev.diamond.ac.uk')
+DISCOURSE_HOST = os.environ.get('DISCOURSE_HOST')
 # Note that this can be obtained from discourse for the desired environment.
 DISCOURSE_API_KEY = os.environ.get("DISCOURSE_API_KEY")
 

--- a/viewer/discourse.py
+++ b/viewer/discourse.py
@@ -22,8 +22,12 @@ def get_user(client, username):
         # User is not known in Discourse or there is a failure accessing Discourse.
         logger.error('discourse.get_user', 'get_user', exc_info=e)
         error = True
-        error_message = 'Error validating user in Discourse. If this is your first post please log on to ' \
-                        'Discourse once to create a User. URL is: ' + settings.DISCOURSE_HOST
+        if settings.DISCOURSE_HOST:
+            error_message = 'Error validating user in Discourse. If this is your first post ' \
+                            + 'please log on to ' \
+                            + 'Discourse once to create a User. URL is: ' + settings.DISCOURSE_HOST
+        else:
+            error_message = 'Please check Discourse Host parameter for Fragalysis'
     else:
         user = user['id']
 
@@ -220,3 +224,21 @@ def list_discourse_posts_for_topic(topic_title):
 
     print('- discourse.get_discourse_posts_for_topic')
     return error, posts
+
+
+def check_discourse_user(user):
+    """Call discourse API to check discourse user exists
+    """
+
+    # Create Discourse client for user
+    client = DiscourseClient(
+        settings.DISCOURSE_HOST,
+        api_username=user.username,
+        api_key=settings.DISCOURSE_API_KEY)
+
+    # Check user is present in Discourse
+    error, error_message, user_id = get_user(client, user.username)
+    if user_id == 0:
+        return error, error_message, 0
+
+    return error, error_message, user_id

--- a/viewer/templates/viewer/react_temp.html
+++ b/viewer/templates/viewer/react_temp.html
@@ -20,8 +20,8 @@
          pk: {{user.pk|default:-1}},
          authenticated: true,
          discourse_available: {{ discourse_available }},
-         user_present_on_discourse: {{ user_present_on_discourse|default:"false"  }},
-         discourse_host: {{ discourse_host|default:"none" }}
+         user_present_on_discourse: {{ user_present_on_discourse }},
+         discourse_host: {{ discourse_host }}
      }
  {% else %}
      var DJANGO_CONTEXT = {

--- a/viewer/templates/viewer/react_temp.html
+++ b/viewer/templates/viewer/react_temp.html
@@ -19,7 +19,9 @@
          email: '{{ user.email|default:"noemail" }}',
          pk: {{user.pk|default:-1}},
          authenticated: true,
-         discourse_available: {{ discourse_available }}
+         discourse_available: {{ discourse_available }},
+         user_present_on_discourse: {{ user_present_on_discourse|default:"false"  }},
+         discourse_host: {{ discourse_host|default:"none" }}
      }
  {% else %}
      var DJANGO_CONTEXT = {

--- a/viewer/templates/viewer/react_temp.html
+++ b/viewer/templates/viewer/react_temp.html
@@ -21,7 +21,7 @@
          authenticated: true,
          discourse_available: {{ discourse_available }},
          user_present_on_discourse: {{ user_present_on_discourse }},
-         discourse_host: {{ discourse_host }}
+         discourse_host: '{{ discourse_host }}'
      }
  {% else %}
      var DJANGO_CONTEXT = {

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -54,7 +54,7 @@ from viewer import filters
 from .forms import CSetForm, UploadKeyForm, CSetUpdateForm, TSetForm
 
 from .tasks import *
-from .discourse import create_discourse_post, list_discourse_posts_for_topic
+from .discourse import create_discourse_post, list_discourse_posts_for_topic, check_discourse_user
 
 
 from viewer.serializers import (
@@ -578,7 +578,7 @@ class ProteinView(ISpyBSafeQuerySet):
 def react(request):
     """
     :param request:
-    :return:
+    :return: viewer/react page with context
     """
     discourse_api_key = settings.DISCOURSE_API_KEY
 
@@ -587,6 +587,17 @@ def react(request):
         context['discourse_available'] = 'true'
     else:
         context['discourse_available'] = 'false'
+
+    # If user is authenticated and a discourse api key is available, then check discourse to
+    # see if user is set up and set up flag in context.
+    user = request.user
+    if user.is_authenticated and discourse_api_key:
+        error, error_message, user_id = check_discourse_user(user)
+        if user_id:
+            context['user_present_on_discourse'] = 'true'
+            context['discourse_host'] = settings.DISCOURSE_HOST
+        else:
+            context['user_present_on_discourse'] = 'false'
 
     return render(request, "viewer/react_temp.html", context)
 

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -583,21 +583,19 @@ def react(request):
     discourse_api_key = settings.DISCOURSE_API_KEY
 
     context = {}
+    context['discourse_available'] = 'false'
     if discourse_api_key:
         context['discourse_available'] = 'true'
-    else:
-        context['discourse_available'] = 'false'
 
     # If user is authenticated and a discourse api key is available, then check discourse to
     # see if user is set up and set up flag in context.
     user = request.user
     if user.is_authenticated and discourse_api_key:
         context['discourse_host'] = settings.DISCOURSE_HOST
+        context['user_present_on_discourse'] = 'false'
         error, error_message, user_id = check_discourse_user(user)
         if user_id:
             context['user_present_on_discourse'] = 'true'
-        else:
-            context['user_present_on_discourse'] = 'false'
 
     return render(request, "viewer/react_temp.html", context)
 

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -592,10 +592,10 @@ def react(request):
     # see if user is set up and set up flag in context.
     user = request.user
     if user.is_authenticated and discourse_api_key:
+        context['discourse_host'] = settings.DISCOURSE_HOST
         error, error_message, user_id = check_discourse_user(user)
         if user_id:
             context['user_present_on_discourse'] = 'true'
-            context['discourse_host'] = settings.DISCOURSE_HOST
         else:
             context['user_present_on_discourse'] = 'false'
 


### PR DESCRIPTION
1 Add user_present_on_discourse (true/false) and discourse_host (environment variable) to react django_context variables when a user logs in (is authenticated) on Fragalysis so that Front end can formulate a suitable message in the situation where the user is not yet present on Discourse.

2. Remove default discourse_host from settings.py. The discourse host should be required to be set in each instance. 

This now requires the stack_discourse_host variable to to be set in the AWX templates in addition to the discourse_api_key when Fragalysis is partnered with Discourse.

Note also that for local development you will need to add "DISCOURSE_HOST: 'https://discourse.xchem-dev.diamond.ac.uk'
"  will now need to be set for local development. 