### PR TITLE
Tags-v02 with to test for tag category.

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -216,13 +216,9 @@ class APIUrlsTestCase(APITestCase):
 
         # Tags tests
 
-        # TagCategory
-        self.tagcategory = TagCategory.objects.create(
-            id = 1,
-            category = "sites",
-            colour =  "FFFFFF",
-            description = "site description"
-        )
+        # TagCategory - Should have been created by the migrations.
+        self.tagcategory = TagCategory.objects.get(id=1)
+
         # MoleculeTag
         self.moltag = MoleculeTag.objects.create(
             id = 1,
@@ -726,9 +722,9 @@ class APIUrlsTestCase(APITestCase):
         response_data = [
             {
                 "id": 1,
-                "category": "sites",
-                "colour": "FFFFFF",
-                "description": "site description"
+                "category": "Sites",
+                "colour": "00CC00",
+                "description": None
             },
             {
                 "id": 1,


### PR DESCRIPTION
Initial Tags backend implementation.
Contains functionality as designed in the initial design document:

New models for MoleculeTag, SessionProjectTag and TagCategory
TagCategory is initialized with 4 categories: Sites, Forum etc. as defined.
APIs to add/update/delete models
New target_molecules API to retrieve all Molecules/tags/tag categories within a Target.
Updated session project API so that it also retrieves any session project tags
Tests for basic APIs
Documentation
Some increased timeout values for calls to the nginx server.