### PR TITLE
Issue 757

### DIFF
--- a/viewer/download_structures.py
+++ b/viewer/download_structures.py
@@ -1,0 +1,544 @@
+"""
+download_structures.py
+
+Methods for downloading a Target Zip file used by the download_structure API.
+"""
+
+import os
+import zipfile
+import datetime
+import uuid
+import shutil
+import fnmatch
+import logging
+
+from django.conf import settings
+
+from viewer.models import (
+    Molecule,
+    Protein,
+    DownloadLinks
+)
+
+logger = logging.getLogger(__name__)
+
+# Filepaths mapping for writing associated files to the zip archive.
+# Note that if this is set to 'aligned' then the files will be placed in
+# the protein code subdirectory of the aligned directory
+# (as for the target upload).
+_ZIP_FILEPATHS = {
+    'pdb_info': ('aligned'),
+    'bound_info': ('aligned'),
+    'cif_info': ('aligned'),
+    'mtz_info': ('aligned'),
+    'map_info': ('aligned'),
+    'sigmaa_info': ('aligned'),
+    'diff_info': ('aligned'),
+    'event_info': ('aligned'),
+    'trans_matrix_info': ('aligned'),
+    'sdf_info': ('aligned'),
+    'single_sdf_file': (''),
+    'metadata_info': (''),
+    'smiles_info': (''),
+    'extra_files': ('extra_files'),
+}
+
+# Dictionary containing all references needed to create the zip file
+# NB you may need to add a version number to this at some point...
+zip_contents = {'proteins': {'pdb_info': {},
+                             'bound_info': {},
+                             'cif_info': {},
+                             'mtz_info': {},
+                             'diff_info': {},
+                             'event_info': {},
+                             'sigmaa_info': {},
+                             'trans_matrix_info': {}
+                             },
+                'molecules': {'sdf_files': {},
+                              'sdf_info': False,
+                              'single_sdf_file': False,
+                              'smiles_info': {}
+                              },
+                'metadata_info': None, }
+
+
+def _clean_filename(filepath):
+    file_split = os.path.splitext(os.path.basename(filepath))
+    if fnmatch.fnmatch(
+            file_split[0],
+            '*_[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]'+
+            '[a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]'):
+        cleaned_filename = file_split[0][:-8] + file_split[1]
+    else:
+        cleaned_filename = os.path.basename(filepath)
+    return cleaned_filename
+
+
+def _add_file_to_zip(ziparchive, param, filepath):
+    """Add the requested file to the zip archive.
+
+    Args:
+        ziparchive: Handle of zip archive
+        param: parameter of filelist
+        filepath: filepath from record
+
+    Returns:
+        [boolean]: [True of record added to error file]
+    """
+    media_root = settings.MEDIA_ROOT
+    if not filepath:
+        return False
+
+    fullpath = os.path.join(media_root, filepath)
+
+    if os.path.isfile(fullpath):
+        cleaned_filename = _clean_filename(filepath)
+        ziparchive.write(fullpath,
+                         os.path.join(_ZIP_FILEPATHS[param],
+                                      cleaned_filename))
+        return False
+
+    return True
+
+
+def _add_file_to_zip_aligned(ziparchive, code, filepath):
+    """Add the requested file to the zip archive.
+
+    Args:
+        ziparchive: Handle of zip archive
+        code: original protein code stripped of any alternate name.
+        filepath: filepath from record
+
+    Returns:
+        [boolean]: [True of record added to error file]
+    """
+    media_root = settings.MEDIA_ROOT
+    if not filepath:
+        return False
+
+    fullpath = os.path.join(media_root, filepath)
+
+    if os.path.isfile(fullpath):
+        cleaned_filename = _clean_filename(filepath)
+        ziparchive.write(fullpath,
+                         os.path.join('aligned', code, cleaned_filename))
+        return False
+
+    return True
+
+
+def _add_file_to_sdf(combined_sdf_file, filepath):
+    """Append the requested sdf file to the single sdf file provided.
+
+    Args:
+        combined_sdf: Handle of combined_sdf_file
+        filepath: filepath from record
+
+    Returns:
+        [boolean]: [True of record added to error file]
+    """
+    media_root = settings.MEDIA_ROOT
+
+    if not filepath:
+        return False
+
+    fullpath = os.path.join(media_root, filepath)
+
+    if os.path.isfile(fullpath):
+        with open(combined_sdf_file, 'a') as f_out:
+            with open(fullpath, 'r') as f_in:
+                f_out.write(f_in.read())
+        return False
+
+    return True
+
+
+def _protein_files_zip(zip_contents, ziparchive, error_file):
+    """Write all protein related data to the ZIP file
+       Returns protein errors
+    """
+    prot_errors = 0
+    for param, files in zip_contents['proteins'].items():
+        if not files:
+            continue
+
+        for prot, file in files.items():
+            if _add_file_to_zip_aligned(ziparchive, prot.split(":")[0], file):
+                error_file.write(
+                    '{},{},{}\n'.format(prot, param, file))
+                prot_errors += 1
+    return prot_errors
+
+
+def _molecule_files_zip(zip_contents, ziparchive, combined_sdf_file, error_file):
+    """Write molecule related data to the ZIP file
+       Returns molecule errors
+    """
+
+    mol_errors = 0
+    for file, prot in zip_contents['molecules']['sdf_files'].items():
+
+        if zip_contents['molecules']['sdf_info'] is True:
+            # Add sdf file on the Molecule record to the archive folder.
+            if _add_file_to_zip_aligned(ziparchive, prot.split(":")[0], file):
+                error_file.write(
+                    '{},{},{}\n'.format(prot, 'sdf_info', file))
+                mol_errors += 1
+
+        # Append sdf file on the Molecule record to the combined_sdf_file.
+        if zip_contents['molecules']['single_sdf_file'] is True:
+            if _add_file_to_sdf(combined_sdf_file, file):
+                error_file.write(
+                    '{},{},{}\n'.format(prot, 'single_sdf_file',
+                                        file))
+                mol_errors += 1
+
+    return mol_errors
+
+
+def _smiles_files_zip(zip_contents, ziparchive, download_path):
+    """Create and write the smiles file to the ZIP file
+    """
+    smiles_filename = os.path.join(download_path, 'smiles.smi')
+    with open(smiles_filename, 'w') as smilesfile:
+        for smi in zip_contents['molecules']['smiles_info']:
+            smilesfile.write(smi + ',')
+    ziparchive.write(
+        smiles_filename,
+        os.path.join(_ZIP_FILEPATHS['smiles_info'],
+                     os.path.basename(smiles_filename)))
+    os.remove(smiles_filename)
+
+
+def _extra_files_zip(ziparchive, target):
+    """If an extra info folder exists at the target root level, then
+    copy the contents to the output file as is.
+    Note that this will always be the latest information - even for
+    preserved searches.
+    """
+
+    extra_files = os.path.join(settings.MEDIA_ROOT, 'targets', target.title,
+                              'extra_files')
+    if os.path.isdir(extra_files):
+        for dirpath, dirs, files in os.walk(extra_files):
+            for file in files:
+                filepath = os.path.join(dirpath, file)
+                ziparchive.write(
+                    filepath,
+                    os.path.join(_ZIP_FILEPATHS['extra_files'], file))
+
+
+def _create_structures_zip(target,
+                           zip_contents,
+                           file_url):
+    """Write a ZIP file containing data from an input dictionary
+
+    Args:
+        target
+        zip_contents
+        file_url
+
+    """
+
+    logger.info('+ _create_structures_zip')
+    download_path = os.path.dirname(file_url)
+    os.makedirs(download_path, exist_ok=True)
+
+    error_filename = os.path.join(download_path, "errors.csv")
+    error_file = open(error_filename, "w")
+    error_file.write("Param, Code, Invalid file reference\n")
+    errors = 0
+
+    # If a single sdf file is also wanted then create file to
+    # add sdf files to a file called {targer}_combined.sdf.
+    combined_sdf_file = None
+    if zip_contents['molecules']['single_sdf_file'] is True:
+        combined_sdf_file = \
+            os.path.join(download_path,
+                         '{}_combined.sdf'.format(target.title))
+
+    with zipfile.ZipFile(file_url, 'w') as ziparchive:
+        # Read through zip_contents to compile the file
+        errors += _protein_files_zip(zip_contents, ziparchive, error_file)
+
+        if zip_contents['molecules']['sdf_files']:
+            errors += _molecule_files_zip(zip_contents, ziparchive,
+                                          combined_sdf_file, error_file)
+
+        # Add combined_sdf_file to the archive.
+        if zip_contents['molecules']['single_sdf_file'] is True \
+                and os.path.isfile(combined_sdf_file) :
+            ziparchive.write(
+                combined_sdf_file,
+                os.path.join(_ZIP_FILEPATHS['single_sdf_file'],
+                             os.path.basename(combined_sdf_file)))
+            os.remove(combined_sdf_file)
+
+        # If smiles info is required, then write one column for each molecule
+        # to a smiles.smi file and then add to the archive.
+        if zip_contents['molecules']['smiles_info']:
+            _smiles_files_zip(zip_contents, ziparchive, download_path)
+
+        # Add the metadata file from the target
+        if zip_contents['metadata_info']:
+            if _add_file_to_zip(ziparchive, 'metadata_info',
+                                zip_contents['metadata_info']):
+                error_file.write(
+                    '{},{},{}\n'.format(target, 'metadata_info',
+                                        zip_contents['metadata_info']))
+                errors += 1
+
+        _extra_files_zip(ziparchive, target)
+
+        error_file.close()
+        if errors > 0:
+            ziparchive.write(error_filename, 'errors.csv')
+        os.remove(error_filename)
+
+
+def _protein_garbage_filter(proteins):
+    """Garbage filter. It seems that Mpro has had some 'references_' added
+    that are not being cleared up properly. Will look at this in future
+    epic, but for now remove them from the download.
+
+    Args:
+        proteins
+
+    Returns:
+        [list]: [update protein list]
+    """
+    return [p for p in proteins
+            if not fnmatch.fnmatch(p['code'], 'references_*')]
+
+
+def _create_structures_dict(target, proteins, protein_params, other_params):
+    """Write a ZIP file containing data from an input dictionary
+
+    Args:
+        target
+        proteins
+        protein_params
+        other_params
+
+    Returns:
+        [dict]: [dictionary containing the file contents]
+    """
+
+    logger.info('+ _create_structures_dict')
+
+    molecules = Molecule.objects.filter(prot_id__in=[protein['id'] for protein
+                                                     in proteins]).values()
+
+    # Read through zip_params to compile the parameters
+    for protein in proteins:
+        for param in protein_params:
+            if protein_params[param] is True:
+                zip_contents['proteins'][param].update({protein['code']: protein[param]})
+
+    if other_params['single_sdf_file'] is True:
+        zip_contents['molecules']['single_sdf_file'] = True
+
+    if other_params['sdf_info'] is True:
+        zip_contents['molecules']['sdf_info'] = True
+
+    # sdf information is held as a file on the Molecule record.
+    if other_params['sdf_info'] is True or \
+            other_params['single_sdf_file'] is True:
+        for molecule in molecules:
+            protein = Protein.objects.get(id=molecule['prot_id_id'])
+            zip_contents['molecules']['sdf_files'].update({molecule['sdf_file']: protein.code})
+
+    # The smiles at molecule level may not be unique.
+    if other_params['smiles_info'] is True:
+        for molecule in molecules:
+            zip_contents['molecules']['smiles_info'].update({molecule['smiles']: None})
+
+    # Add the metadata file from the target
+    if other_params['metadata_info'] is True:
+        zip_contents['metadata_info'] = target.metadata.name
+
+    return zip_contents
+
+
+def get_keep_until():
+    """Return the keep_until time"""
+    return datetime.datetime.now(datetime.timezone.utc) + \
+           datetime.timedelta(hours=1)
+
+
+def get_download_params(request):
+    """Check whether structures have been previously downloaded
+
+    Args:
+        request
+
+    Returns:
+        protein_params, other_params
+    """
+
+    protein_param_flags = ['pdb_info', 'bound_info',
+                           'cif_info', 'mtz_info',
+                           'diff_info', 'event_info',
+                           'sigmaa_info', 'trans_matrix_info']
+    other_param_flags = ['sdf_info', 'single_sdf_file',
+                         'metadata_info', 'smiles_info']
+
+    # protein_params = {'pdb_info': request.data['pdb_info'],
+    #               'bound_info': request.data['bound_info'],
+    #               'cif_info': request.data['cif_info'],
+    #               'mtz_info': request.data['mtz_info'],
+    #               'diff_info': request.data['diff_info'],
+    #               'event_info': request.data['event_info'],
+    #               'sigmaa_info': request.data['sigmaa_info'],
+    #               'trans_matrix_info':
+    #                   request.data['trans_matrix_info']}
+    protein_params = {}
+    for param in protein_param_flags:
+        protein_params[param] = False
+        if param in request.data:
+            if request.data[param] is True or request.data[param] == 'true':
+                protein_params[param] = True
+
+    # other_params = {'sdf_info': request.data['sdf_info'],
+    #                 'single_sdf_file': request.data['single_sdf_file'],
+    #                 'metadata_info': request.data['metadata_info'],
+    #                 'smiles_info': request.data['smiles_info']}
+    other_params = {}
+    for param in other_param_flags:
+        other_params[param] = False
+        if param in request.data:
+            if request.data[param] is True or request.data[param] == 'true':
+                other_params[param] = True
+
+    return protein_params, other_params
+
+
+def check_download_links(request,
+                         target,
+                         proteins):
+    """Check/create the download zip file for dynamic links
+
+    Args:
+        request
+        target
+        proteins
+
+    Returns:
+        [file]: [URL to the file in the media directory]
+    """
+
+
+    logger.info('+ _check_download_links')
+
+    protein_params, other_params = get_download_params(request)
+
+    # Remove 'references_' from protein list if present.
+    proteins = _protein_garbage_filter(proteins)
+
+    # Save the list of protein codes - this is the ispybsafe set for
+    # this user.
+    proteins_list = [p['code'] for p in proteins]
+
+    # For dynamic files, if the target, proteins, protein_params and other_params
+    # are in an existing record then this is a repeat search .
+    # If the zip is there, then we can just return the file_url.
+    # If the record is there but the zip file isn't, then regenerate the zip file.
+    # from the search, to contain the latest information.
+    # If no record is not there at all, then this is a new link.
+
+    if 'static_link' in request.data:
+        if request.data['static_link'] is True or \
+                request.data['static_link'] == 'true':
+            static_link = True
+        else:
+            static_link = False
+    else:
+        static_link = False
+
+    existing_link = DownloadLinks.objects.filter(target_id=target.id)\
+        .filter(proteins=proteins_list) \
+        .filter(protein_params=protein_params)\
+        .filter(other_params=other_params) \
+        .filter(static_link=False)
+
+    if existing_link:
+        if not existing_link[0].zip_file or static_link:
+            zip_contents = _create_structures_dict(target,
+                                                   proteins,
+                                                   protein_params,
+                                                   other_params)
+            _create_structures_zip(target,
+                                   zip_contents,
+                                   existing_link[0].file_url)
+            existing_link[0].keep_zip_until = get_keep_until()
+            existing_link[0].zip_file = True
+            if static_link:
+                # Changing from a dynamic to a static link
+                existing_link[0].static_link = static_link
+                existing_link[0].zip_contents = zip_contents
+            existing_link[0].save()
+        return existing_link[0].file_url
+
+    # Create a new link for this user
+    # /code/media/downloads/<download_uuid>
+    filename = target.title +'.zip'
+    media_root = settings.MEDIA_ROOT
+    file_url = os.path.join(media_root, 'downloads', str(uuid.uuid4()), filename)
+
+    zip_contents = _create_structures_dict(target,
+                                           proteins,
+                                           protein_params,
+                                           other_params)
+
+    _create_structures_zip(target,
+                           zip_contents,
+                           file_url)
+
+    download_link = DownloadLinks()
+    download_link.file_url = file_url
+    if request.user.is_authenticated:
+        download_link.user = request.user
+    else:
+        download_link.user = None
+    download_link.target = target
+    download_link.proteins = proteins_list
+    download_link.protein_params = protein_params
+    download_link.other_params = other_params
+    download_link.static_link = static_link
+    if static_link:
+        download_link.zip_contents = zip_contents
+    download_link.create_date = datetime.datetime.now(datetime.timezone.utc)
+    download_link.keep_zip_until = get_keep_until()
+    download_link.zip_file = True
+    download_link.save()
+
+    return file_url
+
+def recreate_static_file (existing_link):
+    """Recreate static file for existing link
+    """
+    target = existing_link.target
+
+    _create_structures_zip(target,
+                           existing_link.zip_contents,
+                           existing_link.file_url)
+    existing_link.keep_zip_until = get_keep_until()
+    existing_link.zip_file = True
+    existing_link.save()
+
+
+def maintain_download_links():
+    """Maintain zip files
+
+       Physical zip files are removed after 1 hour (or when the next POST call
+       is made) for security reasons and to conserve memory space.
+
+    """
+
+    old_links = DownloadLinks.objects.\
+        filter(keep_zip_until__lt=datetime.datetime.now(datetime.timezone.utc)).\
+        filter(zip_file=True)
+    for old_link in old_links:
+        old_link.zip_file = False
+        old_link.save()
+        shutil.rmtree(os.path.dirname(old_link.file_url), ignore_errors=True)

--- a/viewer/download_structures.py
+++ b/viewer/download_structures.py
@@ -11,6 +11,7 @@ import uuid
 import shutil
 import fnmatch
 import logging
+import copy
 
 from django.conf import settings
 
@@ -323,7 +324,7 @@ def _create_structures_dict(target, proteins, protein_params, other_params):
     Returns:
         [dict]: [dictionary containing the file contents]
     """
-    zip_contents = zip_template
+    zip_contents =  copy.deepcopy(zip_template)
 
     logger.info('+ _create_structures_dict')
 

--- a/viewer/download_structures.py
+++ b/viewer/download_structures.py
@@ -45,7 +45,7 @@ _ZIP_FILEPATHS = {
 
 # Dictionary containing all references needed to create the zip file
 # NB you may need to add a version number to this at some point...
-zip_contents = {'proteins': {'pdb_info': {},
+zip_template = {'proteins': {'pdb_info': {},
                              'bound_info': {},
                              'cif_info': {},
                              'mtz_info': {},
@@ -323,6 +323,7 @@ def _create_structures_dict(target, proteins, protein_params, other_params):
     Returns:
         [dict]: [dictionary containing the file contents]
     """
+    zip_contents = zip_template
 
     logger.info('+ _create_structures_dict')
 
@@ -344,7 +345,7 @@ def _create_structures_dict(target, proteins, protein_params, other_params):
     # sdf information is held as a file on the Molecule record.
     if other_params['sdf_info'] is True or \
             other_params['single_sdf_file'] is True:
-        for molecule in molecules:
+        for molecule in molecule:
             protein = Protein.objects.get(id=molecule['prot_id_id'])
             zip_contents['molecules']['sdf_files'].update({molecule['sdf_file']: protein.code})
 
@@ -396,7 +397,7 @@ def get_download_params(request):
     for param in protein_param_flags:
         protein_params[param] = False
         if param in request.data:
-            if request.data[param] is True or request.data[param] == 'true':
+            if request.data[param] == True or request.data[param] == 'true':
                 protein_params[param] = True
 
     # other_params = {'sdf_info': request.data['sdf_info'],
@@ -407,7 +408,7 @@ def get_download_params(request):
     for param in other_param_flags:
         other_params[param] = False
         if param in request.data:
-            if request.data[param] is True or request.data[param] == 'true':
+            if request.data[param] == True or request.data[param] == 'true':
                 other_params[param] = True
 
     return protein_params, other_params

--- a/viewer/download_structures.py
+++ b/viewer/download_structures.py
@@ -345,7 +345,7 @@ def _create_structures_dict(target, proteins, protein_params, other_params):
     # sdf information is held as a file on the Molecule record.
     if other_params['sdf_info'] is True or \
             other_params['single_sdf_file'] is True:
-        for molecule in molecule:
+        for molecule in molecules:
             protein = Protein.objects.get(id=molecule['prot_id_id'])
             zip_contents['molecules']['sdf_files'].update({molecule['sdf_file']: protein.code})
 

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -61,6 +61,11 @@ from .forms import CSetForm, UploadKeyForm, CSetUpdateForm, TSetForm
 
 from .tasks import *
 from .discourse import create_discourse_post, list_discourse_posts_for_topic, check_discourse_user
+from .download_structures import (
+    check_download_links,
+    recreate_static_file,
+    maintain_download_links
+)
 
 
 from viewer.serializers import (
@@ -97,24 +102,6 @@ from viewer.serializers import (
     TargetMoleculesSerializer,
     DownloadStructuresSerializer
 )
-
-# filepaths mapping for writing associated files to the zip archive.
-_ZIP_FILEPATHS = {
-    'pdb_info': ('pdbs'),
-    'bound_info': ('bound'),
-    'cif_info': ('cifs'),
-    'mtz_info': ('mtzs'),
-    'map_info': ('maps'),
-    'sigmaa_info': ('maps'),
-    'diff_info': ('maps'),
-    'event_info': ('maps'),
-    'trans_matrix_info': ('trans'),
-    'sdf_info': ('sdfs'),
-    'single_sdf_file': ('sdfs'),
-    'metadata_info': (''),
-    'smiles_info': (''),
-}
-
 
 class VectorsView(ISpyBSafeQuerySet):
     """ DjagnoRF view for vectors
@@ -2761,433 +2748,6 @@ class TargetMoleculesView(ISpyBSafeQuerySet):
     filter_fields = ("title",)
 # Classes Relating to Tags - End
 
-# Methods/Classses relating to creating downloaded structures zip files - Start.
-def _add_file_to_zip(ziparchive, param, filepath):
-    """Add the requested file to the zip archive.
-
-    Args:
-        ziparchive: Handle of zip archive
-        code: Fragalysis protein code
-        param: parameter of filelist
-        filepath: filepath from record
-        error_file: Error file handle
-
-    Returns:
-        [boolean]: [True of record added to error file]
-    """
-    media_root = settings.MEDIA_ROOT
-    if not filepath:
-        return False
-
-    fullpath = os.path.join(media_root, filepath)
-
-    if os.path.isfile(fullpath):
-        ziparchive.write(fullpath,
-                         os.path.join(_ZIP_FILEPATHS[param],
-                                      os.path.basename(filepath)))
-        return False
-    else:
-        return True
-
-
-def _add_file_to_sdf(combined_sdf_file, filepath):
-    """Append the requested sdf file to the single sdf file provided.
-
-    Args:
-        combined_sdf: Handle of combined_sdf_file
-        smiles: Smiles from molecule record
-        filepath: filepath from record
-        error_file: Error file handle
-
-    Returns:
-        [boolean]: [True of record added to error file]
-    """
-    media_root = settings.MEDIA_ROOT
-
-    if not filepath:
-        return False
-
-    fullpath = os.path.join(media_root, filepath)
-
-    if os.path.isfile(fullpath):
-        with open(combined_sdf_file, 'a') as f_out:
-            with open(fullpath, 'r') as f_in:
-                f_out.write(f_in.read())
-        return False
-    else:
-        return True
-
-
-def _protein_files_zip(zip_contents, ziparchive, error_file):
-    """Write all protein related data to the ZIP file
-       Returns protein errors
-    """
-    prot_errors = 0
-    for param, files in zip_contents['proteins'].items():
-        if not files:
-            continue
-
-        for prot, file in files.items():
-            if _add_file_to_zip(ziparchive, param, file):
-                error_file.write(
-                    '{},{},{}\n'.format(prot, param, file))
-                prot_errors += 1
-    return prot_errors
-
-
-def _molecule_files_zip(zip_contents, ziparchive, combined_sdf_file, error_file):
-    """Write molecule related data to the ZIP file
-       Returns molecule errors
-    """
-
-    mol_errors = 0
-    for file, mol in zip_contents['molecules']['sdf_files'].items():
-
-        if zip_contents['molecules']['sdf_info'] is True:
-            # Add sdf file on the Molecule record to the archive folder.
-            if _add_file_to_zip(ziparchive, 'sdf_info', file):
-                error_file.write(
-                    '{},{},{}\n'.format(mol, 'sdf_info', file))
-                mol_errors += 1
-
-        # Append sdf file on the Molecule record to the combined_sdf_file.
-        if zip_contents['molecules']['single_sdf_file'] is True:
-            if _add_file_to_sdf(combined_sdf_file, file):
-                error_file.write(
-                    '{},{},{}\n'.format(mol, 'single_sdf_file',
-                                        file))
-                mol_errors += 1
-
-    return mol_errors
-
-
-def _smiles_files_zip(zip_contents, ziparchive, download_path):
-    """Create and write the smiles file to the ZIP file
-    """
-    smiles_filename = os.path.join(download_path, 'smiles.smi')
-    with open(smiles_filename, 'w') as smilesfile:
-        for smi in zip_contents['molecules']['smiles_info']:
-            smilesfile.write(smi + ',')
-    ziparchive.write(
-        smiles_filename,
-        os.path.join(_ZIP_FILEPATHS['smiles_info'],
-                     os.path.basename(smiles_filename)))
-    os.remove(smiles_filename)
-
-
-def _create_structures_zip(target,
-                           zip_contents,
-                           file_url):
-    """Write a ZIP file containing data from an input dictionary
-
-    Args:
-        target
-        zip_contents
-        file_url
-
-    """
-
-    logger.info('+ _create_structures_zip')
-    logger.info('zip_contents: {}'.format(zip_contents))
-    download_path = os.path.dirname(file_url)
-    os.makedirs(download_path, exist_ok=True)
-
-    error_filename = os.path.join(download_path, "errors.csv")
-    error_file = open(error_filename, "w")
-    error_file.write("Param, Code, Invalid file reference\n")
-    errors = 0
-
-    # If a single sdf file is also wanted then create file to
-    # add sdf files to a file called {targer}_combined.sdf.
-    combined_sdf_file = None
-    if zip_contents['molecules']['single_sdf_file'] is True:
-        combined_sdf_file = \
-            os.path.join(download_path,
-                         '{}_combined.sdf'.format(target.title))
-
-    with zipfile.ZipFile(file_url, 'w') as ziparchive:
-        # Read through zip_contents to compile the file
-        errors += _protein_files_zip(zip_contents, ziparchive, error_file)
-
-        if zip_contents['molecules']['sdf_files']:
-            errors += _molecule_files_zip(zip_contents, ziparchive,
-                                              combined_sdf_file, error_file)
-
-        # Add combined_sdf_file to the archive.
-        if zip_contents['molecules']['single_sdf_file'] is True \
-                and os.path.isfile(combined_sdf_file) :
-            ziparchive.write(
-                combined_sdf_file,
-                os.path.join(_ZIP_FILEPATHS['single_sdf_file'],
-                             os.path.basename(combined_sdf_file)))
-            os.remove(combined_sdf_file)
-
-        # If smiles info is required, then write one column for each molecule
-        # to a smiles.smi file and then add to the archive.
-        if zip_contents['molecules']['smiles_info']:
-            _smiles_files_zip(zip_contents, ziparchive, download_path)
-
-        # Add the metadata file from the target
-        if zip_contents['metadata_info']:
-            if _add_file_to_zip(ziparchive, 'metadata_info',
-                                zip_contents['metadata_info']):
-                error_file.write(
-                    '{},{},{}\n'.format(target, 'metadata_info',
-                                        zip_contents['metadata_info']))
-                errors+=1
-
-        error_file.close()
-        if errors > 0:
-            ziparchive.write(error_filename, 'errors.csv')
-        os.remove(error_filename)
-
-
-def _create_structures_dict(target, proteins, protein_params, other_params):
-    """Write a ZIP file containing data from an input dictionary
-
-    Args:
-        target
-        proteins
-        protein_params
-        other_params
-
-    Returns:
-        [dict]: [dictionary containing the file contents]
-    """
-
-    logger.info('+ _create_structures_dict')
-
-    molecules = Molecule.objects.filter(prot_id__in=[protein['id'] for protein
-                                                     in proteins]).values()
-
-    # Dictionary containing all references needed to create the zip file
-    zip_contents = {'proteins': {'pdb_info': {},
-                                 'bound_info': {},
-                                 'cif_info': {},
-                                 'mtz_info': {},
-                                 'diff_info': {},
-                                 'event_info': {},
-                                 'sigmaa_info': {},
-                                 'trans_matrix_info': {}
-                                 },
-                    'molecules': {'sdf_files': {},
-                                  'sdf_info': False,
-                                  'single_sdf_file': False,
-                                  'smiles_info': {}
-                                  },
-                    'metadata_info': None,}
-
-    # Read through zip_params to compile the parameters
-    for protein in proteins:
-        for param in protein_params:
-            if protein_params[param] is True:
-                zip_contents['proteins'][param].update({protein['code']: protein[param]})
-
-    if other_params['single_sdf_file'] is True:
-        zip_contents['molecules']['single_sdf_file'] = True
-
-    if other_params['sdf_info'] is True:
-        zip_contents['molecules']['sdf_info'] = True
-
-    # sdf information is held as a file on the Molecule record.
-    if other_params['sdf_info'] is True or \
-            other_params['single_sdf_file'] is True:
-        for molecule in molecules:
-            zip_contents['molecules']['sdf_files'].update({molecule['sdf_file']: molecule['smiles']})
-
-    # The smiles at molecule level may not be unique.
-    if other_params['smiles_info'] is True:
-        for molecule in molecules:
-            zip_contents['molecules']['smiles_info'].update({molecule['smiles']: None})
-
-    # Add the metadata file from the target
-    if other_params['metadata_info'] is True:
-        zip_contents['metadata_info'] = target.metadata.name
-
-    return zip_contents
-
-
-def get_keep_until():
-    """Return the keep_until time"""
-    return datetime.datetime.now(datetime.timezone.utc) + \
-           datetime.timedelta(hours=1)
-
-
-def get_download_params(request):
-    """Check whether structures have been previously downloaded
-
-    Args:
-        request
-
-    Returns:
-        protein_params, other_params
-    """
-
-    protein_param_flags = ['pdb_info', 'bound_info',
-                           'cif_info', 'mtz_info',
-                           'diff_info', 'event_info',
-                           'sigmaa_info', 'trans_matrix_info']
-    other_param_flags = ['sdf_info', 'single_sdf_file',
-                         'metadata_info', 'smiles_info']
-
-    # protein_params = {'pdb_info': request.data['pdb_info'],
-    #               'bound_info': request.data['bound_info'],
-    #               'cif_info': request.data['cif_info'],
-    #               'mtz_info': request.data['mtz_info'],
-    #               'diff_info': request.data['diff_info'],
-    #               'event_info': request.data['event_info'],
-    #               'sigmaa_info': request.data['sigmaa_info'],
-    #               'trans_matrix_info':
-    #                   request.data['trans_matrix_info']}
-    protein_params = {}
-    for param in protein_param_flags:
-        protein_params[param] = False
-        if param in request.data:
-            if request.data[param] == True or request.data[param] == 'true':
-                protein_params[param] = True
-
-    # other_params = {'sdf_info': request.data['sdf_info'],
-    #                 'single_sdf_file': request.data['single_sdf_file'],
-    #                 'metadata_info': request.data['metadata_info'],
-    #                 'smiles_info': request.data['smiles_info']}
-    other_params = {}
-    for param in other_param_flags:
-        other_params[param] = False
-        if param in request.data:
-            if request.data[param] == True or request.data[param] == 'true':
-                other_params[param] = True
-
-    return protein_params, other_params
-
-
-def _check_download_links(request,
-                          target,
-                          proteins):
-    """Check/create the download zip file for dynamic links
-
-    Args:
-        request
-        target
-        proteins
-
-    Returns:
-        [file]: [URL to the file in the media directory]
-    """
-
-
-    logger.info('+ _check_download_links')
-
-    protein_params, other_params = get_download_params(request)
-
-    # Save the list of protein codes - this is the ispybsafe set for
-    # this user.
-    proteins_list = [p['code'] for p in proteins]
-
-    # For dynamic files, if the target, proteins, protein_params and other_params
-    # are in an existing record then this is a repeat search .
-    # If the zip is there, then we can just return the file_url.
-    # If the record is there but the zip file isn't, then regenerate the zip file.
-    # from the search, to contain the latest information.
-    # If no record is not there at all, then this is a new link.
-
-    if 'static_link' in request.data:
-        if request.data['static_link'] == True or request.data[
-            'static_link'] == 'true':
-            static_link = True
-        else:
-            static_link = False
-    else:
-        static_link = False
-
-    existing_link = DownloadLinks.objects.filter(target_id=target.id)\
-        .filter(proteins=proteins_list) \
-        .filter(protein_params=protein_params)\
-        .filter(other_params=other_params) \
-        .filter(static_link=False)
-
-    if existing_link:
-        if not existing_link[0].zip_file or static_link:
-            zip_contents = _create_structures_dict(target,
-                                                   proteins,
-                                                   protein_params,
-                                                   other_params)
-            _create_structures_zip(target,
-                                   zip_contents,
-                                   existing_link[0].file_url)
-            existing_link[0].keep_zip_until = get_keep_until()
-            existing_link[0].zip_file = True
-            if static_link:
-                # Changing from a dynamic to a static link
-                existing_link[0].static_link = static_link
-                existing_link[0].zip_contents = zip_contents
-            existing_link[0].save()
-        return existing_link[0].file_url
-
-    # Create a new link for this user
-    # /code/media/downloads/<download_uuid>
-    filename = target.title +'.zip'
-    media_root = settings.MEDIA_ROOT
-    file_url = os.path.join(media_root, 'downloads', str(uuid.uuid4()), filename)
-
-    zip_contents = _create_structures_dict(target,
-                                           proteins,
-                                           protein_params,
-                                           other_params)
-
-    _create_structures_zip(target,
-                           zip_contents,
-                           file_url)
-
-    download_link = DownloadLinks()
-    download_link.file_url = file_url
-    if request.user.is_authenticated:
-        download_link.user = request.user
-    else:
-        download_link.user = None
-    download_link.target = target
-    download_link.proteins = proteins_list
-    download_link.protein_params = protein_params
-    download_link.other_params = other_params
-    download_link.static_link = static_link
-    if static_link:
-        download_link.zip_contents = zip_contents
-    download_link.create_date = datetime.datetime.now(datetime.timezone.utc)
-    download_link.keep_zip_until = get_keep_until()
-    download_link.zip_file = True
-    download_link.save()
-
-    return file_url
-
-def _recreate_static_file (existing_link):
-    """Recreate static file for existing link
-    """
-    target = existing_link.target
-
-    _create_structures_zip(target,
-                           existing_link.zip_contents,
-                           existing_link.file_url)
-    existing_link.keep_zip_until = get_keep_until()
-    existing_link.zip_file = True
-    existing_link.save()
-
-
-def _maintain_download_links():
-    """Maintain zip files
-
-       Physical zip files are removed after 1 hour (or when the next POST call
-       is made) for security reasons and to conserve memory space.
-
-    """
-
-    old_links = DownloadLinks.objects.\
-        filter(keep_zip_until__lt=datetime.datetime.now(datetime.timezone.utc)).\
-        filter(zip_file=True)
-    for old_link in old_links:
-        logger.info('old_link: {}'.format(old_link.file_url))
-        old_link.zip_file = False
-        old_link.save()
-        shutil.rmtree(os.path.dirname(old_link.file_url), ignore_errors=True)
-
 
 class DownloadStructures(ISpyBSafeQuerySet):
     """Django view that uses a selected subset of the target data
@@ -3284,10 +2844,10 @@ class DownloadStructures(ISpyBSafeQuerySet):
                     'Content-Disposition'] = 'attachment; filename="%s"' % file_name
                 response['Content-Length'] = os.path.getsize(file_url)
                 return response
-            else:
-                return Response("File_url is not found or no longer active")
-        else:
-            return Response("Please provide file_url parameter from post response")
+
+            return Response("File_url is not found or no longer active")
+
+        return Response("Please provide file_url parameter from post response")
 
 
     def create(self, request):
@@ -3307,23 +2867,23 @@ class DownloadStructures(ISpyBSafeQuerySet):
 
             if existing_link and existing_link[0].static_link:
                 if not existing_link[0].zip_file:
-                    _recreate_static_file (existing_link[0])
-                _maintain_download_links()
+                    recreate_static_file (existing_link[0])
+                maintain_download_links()
                 return Response({"file_url": existing_link[0].file_url})
-            else:
-                return Response(
-                    {"message": "This file_url is for static files: {}".
-                        format(file_url)})
+
+            return Response(
+                {"message": "This file_url is for static files: {}".
+                    format(file_url)})
 
         # Dynamic files
         target_name = request.data['target_name']
         target = None
 
         # Check target is valid
-        for t in self.queryset:
-            logger.info(t.title)
-            if t.title == target_name:
-                target = t
+        for targ in self.queryset:
+            logger.info(targ.title)
+            if targ.title == target_name:
+                target = targ
                 break
 
         if not target:
@@ -3349,10 +2909,9 @@ class DownloadStructures(ISpyBSafeQuerySet):
                 {"message": "Please enter list of valid protein codes for" +
                  "target: {}, proteins: {} ".format(target.id, proteins_list)})
 
-        filename_url = _check_download_links(request,
-                                             target,
-                                             proteins)
+        filename_url = check_download_links(request,
+                                            target,
+                                            proteins)
 
-        _maintain_download_links()
+        maintain_download_links()
         return Response({"file_url": filename_url})
-# Methods/Classses relating to creating downloaded structures zip files - Emd.

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -2891,7 +2891,7 @@ class DownloadStructures(ISpyBSafeQuerySet):
                 {"message": "Please enter a permitted target name."})
 
         if request.data['proteins']:
-            proteins_list = [p.strip()
+            proteins_list = [p.split(":")[0].strip()
                             for p in request.data['proteins'].split(',')]
         else:
             proteins_list = []

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -2891,8 +2891,8 @@ class DownloadStructures(ISpyBSafeQuerySet):
                 {"message": "Please enter a permitted target name."})
 
         if request.data['proteins']:
-            proteins_list = [p.split(":")[0].strip()
-                            for p in request.data['proteins'].split(',')]
+            proteins_list = [p.strip()
+                             for p in request.data['proteins'].split(',')]
         else:
             proteins_list = []
 


### PR DESCRIPTION
See: https://github.com/m2ms/fragalysis-frontend/issues/757

1. Random strings caused by duplicate overwrites suppressed
2. directory structure now matches the input structure (aligned/protein_code/*files*)
3. If an "extra_files" folder is added to the target, then it and any files within it will be copied to every output file (Note that if you don't want to upload any new targets right now I can manually create the folder in the media server for any targets you want).
4. Any proteins (and linked files) starting with the name 'references_' are suppressed. - All of these seem to have appeared in Mpro in February/March last year. 