### PR TITLE
Issue 758

### DIFF
--- a/viewer/download_structures.py
+++ b/viewer/download_structures.py
@@ -8,7 +8,6 @@ import os
 import zipfile
 import datetime
 import time
-import pytz
 import uuid
 import shutil
 import fnmatch
@@ -16,6 +15,7 @@ import logging
 import copy
 import json
 import pandoc
+import pytz
 
 from django.conf import settings
 


### PR DESCRIPTION
Edges cases:
1. Now checks if the target has been uploaded since the file was originally created. If so, create.
2. Creates the download link before the file is created - handling duplicate calls from different browser windows better. Note - error checking on the front end is also being changed to improve error response on the second browser window. 