### PR TITLE
Issue 790

### DIFF
--- a/doc_templates/README.md
+++ b/doc_templates/README.md
@@ -1,9 +1,41 @@
 # Download Readme Template
 
-The download_readme_template file is copied and used as a template for the documentation included in the zip files created by the download structures API:
+The download_readme_template file is copied and used as a template for the Directory structure section of the documentation included in the zip files created by the download structures API:
 *api/download_structures.
 
-The 'Snapshot Details' section is updated to include the following information:
+It is placed in an overall structure as follows:
+
+# Documentation for the downloaded zipfile  [Top heading]
+## Download details  [subheading]
+### Download URLs  [sub-subheading]
+(** Note to be updated**)
+_Download URL_: https://fragalysis.xchem.diamond.ac.uk/viewer/react/download/tag/a7ea4b13-90b2-4040-8396-6d3fe7b111a3
+(** Note to be added**)
+_Download snapshot_:  https://https://fragalysis.xchem.diamond.ac.uk/viewer/react/projects/1350/1010"
+`[Ensure they render as clickable hyperlink in the pdf, and include https://]`
+
+### Download options selected
+(** Note to be added**)
+The following options were checked in the download dialogue: 
+* Selected: All structures
+* Selected: PanDDA Event maps - primary evidence
+* Selected: Incremental - always up-to-date with latest structures
+* Selected: Single SDF of all ligands
+
+[use actual words in the modal - just type them across if necessary]
+
+### Download command (JSON)   
+JSON command sent from front-end to backend to generate the download.  This can be reused programmatically as a POST command
+
+The actual JSON (**Note: To be updated currently taken from request, but should be taken from front end**)
+
+## Directory structure  [subheading] 
+`[The text from download_readme_template.md.]`
+
+## Files included
+`[Bulleted List of files in zip]`
+
+
  
 - The Download URL
 - The API parameters used

--- a/doc_templates/download_readme_template.md
+++ b/doc_templates/download_readme_template.md
@@ -1,4 +1,4 @@
-# Fragalysis Download Directory Sturcture
+## Directory structure
 
 A fragalysis download will contain 2-3 folders and some additional files at the top level directory.
 
@@ -6,11 +6,11 @@ At the top level there are 2 files. `metadata.csv` and `smiles.smi`. These are b
 
 `[TARGETNAME]_combined.sdf` may also be present which will contain all the ligand sdf files in a single sdf file.
 
-## aligned directory
+### Aligned directory
 
 The aligned directory contains a subdirectory for each ligand that was selected for downloading.
 
-### Contents of aligned ligand subdirectory
+#### Contents of aligned ligand subdirectory
 
 Depending on your selection of options when downloading the data the follow file suffixes may be present
 
@@ -22,11 +22,11 @@ Depending on your selection of options when downloading the data the follow file
 - [ligand_name].sdf - The Ligand molecule in sdf format
 - [ligand_name]\_transform.json - Tranformation matrix and vector in json format used to align all data together.
 
-## crystallographic directory
+### Crystallographic directory
 
 The crystallographic folder contains the unprocessed versions of all data found in the aligned folder. As one crystal can have mutliple ligands we provide the input crystallographic files once to avoid redundancy and keep download sizes to a minimum.
 
-### Contents of crystal subdirectory
+#### Contents of crystal subdirectory
 
 Depending on your selection of options when downloading the data the follow file suffixes may be present:
 
@@ -37,9 +37,7 @@ Depending on your selection of options when downloading the data the follow file
 - [crystal_name]\_2fofc.(map/ccp4) - estimate of the true electron density from diffraction data and atomic model.
 - [crystal_name]\_fofc.(map/ccp4) - difference electron density map, negative density typically represents where no electron density is found but exists in the atom model. Positive densities represent electron density without mapped atom model.
 
-## extra_files
+### extra_files
 
 If this is present the files in this folder will have been added by the uploader of the data and has no defined structure. As a result we cannot guess what the contents of the file may be but we hope that the uploader of the extra files will have provided a similar
 Files in this folder will be added by the uploader and are largely freeform. Hopefully there will be a readme inside to describe each of the added files.
-
-## Snapshot Details 

--- a/viewer/download_structures.py
+++ b/viewer/download_structures.py
@@ -234,12 +234,15 @@ def _extra_files_zip(ziparchive, target):
 def _get_external_download_url(download_path, host):
     """Returns the external download URL from the internal url for
     the documentation.
-    This a bit messy but requirements change...
+    This a bit messy but requirements change and this should be replaced
+    by data from the frontend in a future issue.
     """
 
     download_base = os.path.join(settings.MEDIA_ROOT, 'downloads')
     download_uuid = download_path.replace(download_base, "")
-    external_path = os.path.join(host, 'viewer/react/download/tag')
+    external_path = os.path.join(
+        settings.SECURE_PROXY_SSL_HEADER[1] + '://' + host,
+        'viewer/react/download/tag')
     external_path = external_path+download_uuid
 
     return external_path
@@ -254,22 +257,30 @@ def _document_file_zip(ziparchive, download_path, original_search, host):
 
     readme_filepath = os.path.join(download_path, 'Readme.md')
     pdf_filepath = os.path.join(download_path, 'Readme.pdf')
-    shutil.copyfile(template_file, readme_filepath)
 
-    with open(readme_filepath, "a") as readme:
-        # Link
-        readme.write("### Download Link\n")
+    with open(readme_filepath, "a") as readme, \
+            open(template_file, "r") as template:
+        readme.write("# Documentation for the downloaded zipfile\n")
+        # Download links
+        readme.write("## Download details\n")
+        readme.write("### Download URLs\n")
+        readme.write("- Download URL: <")
         ext_url = _get_external_download_url(download_path, host)
-        readme.write(ext_url[0:77]+"\n")
-        readme.write(ext_url[77:]+"\n")
+        readme.write(ext_url+">\n")
 
         # Original Search
-        readme.write("\n### Original Search (JSON)\n")
-        readme.write("```"+json.dumps(original_search)+"```\n")
+        readme.write("\n### Download command (JSON)\n")
+        readme.write("JSON command sent from front-end to backend "
+                     "to generate the download. This can be reused "
+                     "programmatically as a POST command:\n\n")
+        readme.write("```"+json.dumps(original_search)+"```\n\n")
+
+        # Download Structure from the template
+        readme.write(template.read())
 
         # Files Included
         list_of_files = ziparchive.namelist()
-        readme.write("\n### Files Included\n")
+        readme.write("\n## Files included\n")
         list_of_files.sort()
         for filename in list_of_files:
             readme.write('- '+filename+'\n')

--- a/viewer/download_structures.py
+++ b/viewer/download_structures.py
@@ -231,21 +231,21 @@ def _extra_files_zip(ziparchive, target):
                     filepath,
                     os.path.join(_ZIP_FILEPATHS['extra_files'], file))
 
-def _get_external_download_url(download_path, host):
-    """Returns the external download URL from the internal url for
-    the documentation.
-    This a bit messy but requirements change and this should be replaced
-    by data from the frontend in a future issue.
-    """
-
-    download_base = os.path.join(settings.MEDIA_ROOT, 'downloads')
-    download_uuid = download_path.replace(download_base, "")
-    external_path = os.path.join(
-        settings.SECURE_PROXY_SSL_HEADER[1] + '://' + host,
-        'viewer/react/download/tag')
-    external_path = external_path+download_uuid
-
-    return external_path
+# def _get_external_download_url(download_path, host):
+#     """Returns the external download URL from the internal url for
+#     the documentation.
+#     This a bit messy but requirements change and this should be replaced
+#     by data from the frontend in a future issue.
+#     """
+#
+#     download_base = os.path.join(settings.MEDIA_ROOT, 'downloads')
+#     download_uuid = download_path.replace(download_base, "")
+#     external_path = os.path.join(
+#         settings.SECURE_PROXY_SSL_HEADER[1] + '://' + host,
+#         'viewer/react/download/tag')
+#     external_path = external_path+download_uuid
+#
+#     return external_path
 
 def _document_file_zip(ziparchive, download_path, original_search, host):
     """Create the document file
@@ -263,10 +263,11 @@ def _document_file_zip(ziparchive, download_path, original_search, host):
         readme.write("# Documentation for the downloaded zipfile\n")
         # Download links
         readme.write("## Download details\n")
-        readme.write("### Download URLs\n")
-        readme.write("- Download URL: <")
-        ext_url = _get_external_download_url(download_path, host)
-        readme.write(ext_url+">\n")
+        # Removed as the URL wasn't being generated correctly.
+        #readme.write("### Download URLs\n")
+        #readme.write("- Download URL: <")
+        #ext_url = _get_external_download_url(download_path, host)
+        #readme.write(ext_url+">\n")
 
         # Original Search
         readme.write("\n### Download command (JSON)\n")


### PR DESCRIPTION
See: https://github.com/m2ms/fragalysis-frontend/issues/790

Download structures documentation:
- Download details section moved to top of document. 
- Document structure section moved down and spelling/case changes made.
- Download URL: Temporarily removed.
- Download command -> additional text

Notes:    
    ReadMe will continue to be generated and added to the zip at original construction of file (this will change in part 2 - https://github.com/m2ms/fragalysis-frontend/issues/785.
    This part requires no changes to the frontend.
