### PR TITLE
Swap to rdMolDraw2D.MolDraw2DSVG(width, height) (utils.py) to match f…

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -102,7 +102,7 @@ def draw_mol(
     :param smiles: the SMILES to render
     :param height: the height in px
     :param width: the width in px
-    :return: an SVG as a string of the inage
+    :return: an SVG as a string of the image
     """
     if mol is None:
         mol = Chem.MolFromSmiles(smiles)
@@ -134,17 +134,15 @@ def draw_mol(
         return response
     else:
         rdMolDraw2D.PrepareMolForDrawing(mol, wedgeBonds=False)
-        # Note that width and height are the wrong way round here to match
-        # a call from the front end. When the front end is fixed, this
-        # can be corrected to:
-        # drawer = rdMolDraw2D.MolDraw2DSVG(width, height)
-        drawer = rdMolDraw2D.MolDraw2DSVG(height, width)
+        drawer = rdMolDraw2D.MolDraw2DSVG(width, height)
         drawopt = drawer.drawOptions()
         drawopt.clearBackground = False
         drawopt.fixedBondLength = 30
         drawopt.padding = 0.01
         drawopt.bondLineWidth = 1
         drawopt.additionalAtomLabelPadding = 0.15
+        # Fix font size to 8 for now - it will become configurable through
+        # a new parameter.
         drawopt.minFontSize = 8
         drawopt.maxFontSize = 8
 
@@ -288,8 +286,6 @@ def get_highlighted_diffs(request):
     if "width" in request.GET:
         width = int(request.GET["width"])
     return HttpResponse(highlight_diff(prb_mol=prb_smiles, ref_mol=ref_smiles, height=height, width=width))
-
-
 
 
 def mol_view(request):


### PR DESCRIPTION
…rontend.

This is the backend change to swap the width and height around - see https://github.com/m2ms/fragalysis-frontend/issues/762 for the full story.

Boris is building the Frontend as we speak so I've assigned both Ruben and Boris as reviewers so Boris is notified.