### PR TITLE
Patch the molecule/target SD and MOL Files during download (895)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,5 @@ RUN chmod +x launch-stack.sh
 COPY django_nginx.conf /etc/nginx/sites-available/default.conf
 RUN ln -s /etc/nginx/sites-available/default.conf /etc/nginx/sites-enabled
 COPY nginx.conf /etc/nginx/nginx.conf
-RUN mkdir /srv/logs/
+RUN mkdir /srv/logs/ && \
+    mkdir /code/logs


### PR DESCRIPTION
The download logic has been adjusted to adjust the content of individual ".sdf" and ".mol" files so that the first line of the file contains the target name if the original file's first line is blank.

This has been testing on a limited set of data on a dev stack and appears to function correctly.