### PR TITLE
Patch for empty apo_desolve_info Protein values

### DIFF
--- a/viewer/views.py
+++ b/viewer/views.py
@@ -3108,7 +3108,6 @@ class JobFileTransferView(viewsets.ModelViewSet):
         logger.info('+ squonk_project=%s', squonk_project)
         logger.info('+ transfer_root=%s', transfer_root)
 
-        transfer_target = None
         if job_transfer:
 
             # A pre-existing transfer...

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -3108,7 +3108,11 @@ class JobFileTransferView(viewsets.ModelViewSet):
         logger.info('+ squonk_project=%s', squonk_project)
         logger.info('+ transfer_root=%s', transfer_root)
 
+        transfer_target = None
         if job_transfer:
+
+            # A pre-existing transfer...
+            transfer_target = job_transfer.target.title
             if (job_transfer.transfer_status == 'PENDING' or
                     job_transfer.transfer_status == 'STARTED'):
 


### PR DESCRIPTION
This patch improves the squonk job execution by "assuming" that if the database `Protein.apo_desolve_info` column is empty, that the file *might* be found in the `targets/{target.title}/aligned/{protein_code}` directory. i.e the `CD44MMA-x0017_0A` PDB file can be found in `targets/CD44MMA/aligned/CD44MMA-x0017_0A` called `CD44MMA-x0017_0A_apo-desolv.pdb`.

> PDB Protein records are present on developer stack databases but some are not present on staging - due to the DM record being migrated after the corresponding data had been uploaded? In staging there are files present in the corresponding `aligned` directory.

This code tries to find the file in that directory if the `Protein.apo_desolve_info` column is empty/blank.
