### PR TITLE
Fixes for squonk auto-upload

### DIFF
--- a/viewer/squonk_job_file_transfer.py
+++ b/viewer/squonk_job_file_transfer.py
@@ -119,7 +119,7 @@ def sdf_file(field, trans_dir, protein_code, target):
     mol = Molecule.objects.get(prot_id=protein.id)
     file = getattr(mol, field)
     if not file:
-        logger.warning(
+        logger.error(
             'No file (field=%s trans_dir=%s protein_code=%s target=%s)',
             field, trans_dir, protein_code, target)
         return None
@@ -185,11 +185,11 @@ def prot_file(field, trans_dir, protein_code, target):
             f"{lean_protein_code}/{lean_protein_code}_apo-desolv.pdb"
         )
         if os.path.isfile(anticipated_path):
-            logger.info('%s has no value but found %s', field, anticipated_path)
+            logger.warning('%s has no value but found %s', field, anticipated_path)
             in_path = anticipated_path
         else:
-            logger.warning('%s has no value and %s does not exist',
-                           field, anticipated_path)
+            logger.error('%s has no value and %s does not exist',
+                         field, anticipated_path)
 
     # Have we got an input file (via DB or 'guessing')?
     if in_path:

--- a/viewer/squonk_job_file_upload.py
+++ b/viewer/squonk_job_file_upload.py
@@ -79,7 +79,7 @@ def _insert_sdf_blank_mol(job_request, transition_time, sdf_filename):
     # Compound set reference URL.
     # What's the https-prefixed URL to the instance?
     # The record's URL is relative to the API.
-    ref_url = settings.SQUONK_UI_URL
+    ref_url = settings.SQUONK2_UI_URL
     if ref_url.endswith('/'):
         ref_url += job_request.squonk_url_ext
     else:

--- a/viewer/squonk_job_file_upload.py
+++ b/viewer/squonk_job_file_upload.py
@@ -60,8 +60,9 @@ Diamond Light Source
 $$$$
 """
 
-# Expected Job parameter file suffix
-_JOB_PARAM_FILE_SUFFIX = '_params.json'
+# Expected Job parameter file suffix.
+# Jobs are acceptable candidates if they produce a file with this extension.
+_JOB_PARAM_FILE_SUFFIX = '.meta.json'
 
 
 def _insert_sdf_blank_mol(job_request, transition_time, sdf_filename):
@@ -146,7 +147,7 @@ def process_compound_set_file(jr_id,
 
     # The temporary files we plan to upload to...
     tmp_sdf_filename = os.path.join(upload_dir, 'job.sdf')
-    tmp_param_filename = os.path.join(upload_dir, 'job_params.json')
+    tmp_param_filename = os.path.join(upload_dir, 'job.meta.json')
 
     # The actual file we expect to create (after processing the temporary files)...
     sdf_filename = os.path.join(upload_dir, job_output_filename)
@@ -163,12 +164,14 @@ def process_compound_set_file(jr_id,
     logger.info("Squonk API token=%s", token)
     logger.info("Squonk API instance_id=%s", instance_id)
 
+    logger.info("Expecting Squonk path='%s'", job_output_path)
+
     # Get the parameter file...
     #         --------------
     job_output_param_filename = os.path\
         .splitext(job_output_filename)[0] + _JOB_PARAM_FILE_SUFFIX
-    logger.info("Trying to get parameter file (path=%s filename=%s)...",
-                job_output_path, job_output_param_filename)
+    logger.info("Expecting Squonk job_output_param_filename='%s'...",
+                job_output_param_filename)
     result = DmApi.get_unmanaged_project_file_with_token(
         token=token,
         project_id=jr.squonk_project,
@@ -182,8 +185,8 @@ def process_compound_set_file(jr_id,
     else:
         # Got the parameter file so now get the SDF...
         #                               -----------
-        logger.warning('Trying to get SDF (path=%s filename=%s)...',
-                       job_output_path, job_output_filename)
+        logger.info("Expecting Squonk job_output_filename='%s'...",
+                    job_output_filename)
         result = DmApi.get_unmanaged_project_file_with_token(
             token=token,
             project_id=jr.squonk_project,
@@ -204,26 +207,76 @@ def process_compound_set_file(jr_id,
 #                instance_id=instance_id,
 #                token=token)
 
-    if got_all_files:
-        # If we have an SDF and parameter file
-        # apply the blank molecule to the uploaded file
-        # and then insert new parameters as we write to the actual SDF file.
-        # i.e. we put a blank molecule in tmp.sdf and then apply parameters
-        # as we re-write to {outfile}.
-        logger.info('Uploaded parameters to %s', tmp_param_filename)
-        logger.info('Uploaded SDF to %s', tmp_sdf_filename)
-        logger.info('Generating %s', sdf_filename)
-
-        # Insert our 'blank molecule' into the uploaded file...
-        _insert_sdf_blank_mol(jr, transition_time, tmp_sdf_filename)
-        with open(tmp_param_filename, 'r') as param_file:
-            params = json.loads(param_file.read())
-            add_prop_to_sdf(tmp_sdf_filename, sdf_filename, params)
-
-        logger.info('Done job compound file (%s)', jr_id)
-    else:
+    if not got_all_files:
         logger.warning('Not processing. Either %s or %s is missing',
                        tmp_sdf_filename, tmp_param_filename)
+        return sdf_filename
 
-    # Return the name of the file (which will exist if we pulled two files).
+    param_size = os.path.getsize(tmp_param_filename)
+    sdf_size = os.path.getsize(tmp_sdf_filename)
+    logger.info('Uploaded parameters to %s [%s bytes]', tmp_param_filename, param_size)
+    logger.info('Uploaded SDF to %s [%s bytes]', tmp_sdf_filename, sdf_size)
+
+    # Uploaded files cannot be empty.
+    if param_size == 0 or sdf_size == 0:
+        logger.warning('Not processing. Either the param file or SDF is empty')
+        return sdf_filename
+
+    # Got both files (non-empty) if we get gere...
+
+    # Apply the blank molecule to the uploaded file
+    # and then insert new parameters as we write to the actual SDF file.
+    # i.e. we put a blank molecule in tmp.sdf and then apply parameters
+    # as we re-write to {outfile}.
+
+    logger.info('Generating %s...', sdf_filename)
+
+    # Insert our 'blank molecule' into the uploaded file...
+    _insert_sdf_blank_mol(jr, transition_time, tmp_sdf_filename)
+
+    # Insert annotations...
+    # The param file is a Squonk ".meta.json" file.
+    # It should have an 'annotations' list with a 'fields' map in the list.
+    #
+    #   {'annotation_version':
+    #           '0.0.1',
+    #           'created': '2022-08-24T09:03:36.973340',
+    #           'description': 'Fragmenstein combine',
+    #           'fields': {'DDG': {'active': True,
+    #                              'description': 'Delta deta G',
+    #                              'required': True,
+    #                              'type': 'number'},
+    #                      'smiles': {'active': True,
+    #                                 'description': 'Molecule SMILES',
+    #                                 'required': False,
+    #                                 'type': 'string'}},
+    #
+    # We take every field as the key and the description as the value.
+    # If anything goes wrong we erase the SD file and return
+    params = {}
+    with open(tmp_param_filename, 'r') as param_file:
+        meta = json.loads(param_file.read())
+        if 'annotations' not in meta or len(meta['annotations']) == 0:
+            logger.warning('Not processing. No annotations in %s',
+                           tmp_param_filename)
+            return sdf_filename
+        for annotation in meta['annotations']:
+            if 'fields' in annotation:
+                for key, value in annotation['fields'].items():
+                    if 'description' not in value:
+                        logger.warning('Annotation field %s in %s has no "description"',
+                                       key, tmp_param_filename)
+                    else:
+                        params[key] = value['description']
+
+    if params:
+        logger.info('Extracted %s from %s - adding to %s...',
+                    params, tmp_param_filename, tmp_sdf_filename)
+        add_prop_to_sdf(tmp_sdf_filename, sdf_filename, params)
+        logger.info('Generated job compound file %s (%s)', sdf_filename, jr_id)
+    else:
+        logger.info('Found no suitable fields in %s', tmp_param_filename)
+
+    # Return the name of the file
+    # (which will exist if we pulled two files and all went well).
     return sdf_filename

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -3460,7 +3460,7 @@ class JobCallBackView(viewsets.ModelViewSet):
 
         # If it's not suitably named, leave
         expected_squonk_filename = 'merged.sdf'
-        if not job_output_filename != expected_squonk_filename:
+        if job_output_filename != expected_squonk_filename:
             # Incorrectly named file - nothing to get/upload.
             logger.info('SUCCESS but not uploading.'
                         ' Expected "%s" as job_output_filename.'

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -3434,7 +3434,7 @@ class JobCallBackView(viewsets.ModelViewSet):
 
         # SUCCESS ... automatic upload?
         #
-        # Only continue if the target file begins 'results_' and ends '.sdf'.
+        # Only continue if the target file is 'merged.sdf'.
         # For now there must be an '--outfile' in the job info's 'command'.
         # Here we have hard-coded the expectations because the logic to identify the
         # command's outputs is not fully understood.
@@ -3458,13 +3458,13 @@ class JobCallBackView(viewsets.ModelViewSet):
         logging.info('job_output_path="%s"', job_output_path)
         logging.info('job_output_filename="%s"', job_output_filename)
 
-        # If it's not a suitably named SD-File, leave
-        if not job_output_filename.lower().startswith('results_')\
-                or not job_output_filename.lower().endswith('.sdf'):
+        # If it's not suitably named, leave
+        expected_squonk_filename = 'merged.sdf'
+        if not job_output_filename != expected_squonk_filename:
             # Incorrectly named file - nothing to get/upload.
             logger.info('SUCCESS but not uploading.'
-                        ' Unsupported job_output_filename'
-                        ' (%s)"', job_output_filename)
+                        ' Expected "%s" as job_output_filename.'
+                        ' Found "%s"', expected_squonk_filename, job_output_filename)
             return HttpResponse(status=204)
 
         if jr.upload_status != 'PENDING':


### PR DESCRIPTION
- This fixes a number of issues pulling files back from squonk
- The files are now pulled back and adjusted based on parameters generated by the job
- The file is then submitted as a new compound/computed set
- File expectation now changed - the upload expects the files `merged.sdf` and `merged.meta.json` (which are generated by the Job)

The operation fails at this point with two property errors, but the basic transfer, job execution and re-transfer now appear to work.

1. `ref_pdb` (missing)
2. `original SMILES` (present as `smiles`)