### PR TITLE
Multi-value version

### DIFF
--- a/fragalysis/views.py
+++ b/fragalysis/views.py
@@ -1,4 +1,5 @@
 # Classes/Methods to override default OIDC Views (Keycloak authentication)
+import os
 from pathlib import Path
 
 from mozilla_django_oidc.views import OIDCLogoutView
@@ -22,10 +23,39 @@ class LogoutView(OIDCLogoutView):
 
 
 def version(request):
-    """A simple endpoint that returns the content of the /code/VERSION file.
+    """A simple endpoint that returns the content of the /code/VERSION file
+    for the stack version and container environment variables for the frontend
+    and backend.
+
     The VERSION file is adjusted during the CI process and should contain
     the TAG used to create an official build. For unofficial builds
     the version is likely to contain a CI reference.
     """
-    version = Path('/code/VERSION').read_text(encoding='utf-8').strip()
-    return JsonResponse({'version': version})
+    undefined_value = "undefined"
+
+    stack_version = Path('/code/VERSION').read_text(encoding='utf-8').strip()
+
+    # b/e and f/e origin comes form container environment variables.
+    #
+    # We also need to deal with empty or unset strings
+    # so the get() default does not help
+    be_namespace = os.envrion.get('BE_NAMESPACE')
+    if not be_namespace:
+        be_namespace = undefined_value
+
+    be_image_tag = os.envrion.get('BE_IMAGE_TAG')
+    if not be_image_tag:
+        be_image_tag = undefined_value
+
+    fe_namespace = os.envrion.get('FE_NAMESPACE')
+    if not fe_namespace:
+        fe_namespace = undefined_value
+
+    fe_branch = os.envrion.get('FE_BRANCH')
+    if not fe_branch:
+        fe_branch = undefined_value
+
+    version_response = {'version': {'backend': f'{be_namespace}.{be_image_tag}',
+                                    'frontend': f'{fe_namespace}.{fe_branch}',
+                                    'stack': stack_version}}
+    return JsonResponse(version_response)

--- a/fragalysis/views.py
+++ b/fragalysis/views.py
@@ -39,19 +39,19 @@ def version(request):
     #
     # We also need to deal with empty or unset strings
     # so the get() default does not help
-    be_namespace = os.envrion.get('BE_NAMESPACE')
+    be_namespace = os.environ.get('BE_NAMESPACE')
     if not be_namespace:
         be_namespace = undefined_value
 
-    be_image_tag = os.envrion.get('BE_IMAGE_TAG')
+    be_image_tag = os.environ.get('BE_IMAGE_TAG')
     if not be_image_tag:
         be_image_tag = undefined_value
 
-    fe_namespace = os.envrion.get('FE_NAMESPACE')
+    fe_namespace = os.environ.get('FE_NAMESPACE')
     if not fe_namespace:
         fe_namespace = undefined_value
 
-    fe_branch = os.envrion.get('FE_BRANCH')
+    fe_branch = os.environ.get('FE_BRANCH')
     if not fe_branch:
         fe_branch = undefined_value
 


### PR DESCRIPTION
Now, a GET from `/version` now returns the following structure: - 

```json
{"version":
  {"backend": "alanbchristie:703.2",
   "frontend": "xchem:master",
   "stack": "xchem:0.0.0"}}
```
