### PR TITLE
Fix JobRequest race-condition

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ gunicorn==20.0.4
 idna==2.10
 image==1.5.32
 importlib-metadata==1.7.0
-im-squonk2-client==1.3.0
+im-squonk2-client==1.15.1
 ipaddress==1.0.23
 ipython==7.17.0
 ipython-genutils==0.2.0
@@ -101,6 +101,7 @@ Rx==1.6.1
 scandir==1.10.0
 SecretStorage==3.1.2
 sentry-sdk==0.16.3
+shortuuid==1.0.11
 simplegeneric==0.8.1
 simplejson==3.17.2
 singledispatch==3.4.0.3

--- a/viewer/models.py
+++ b/viewer/models.py
@@ -1188,7 +1188,7 @@ class JobRequest(models.Model):
     # For us this will contain a 'task_id', 'instance_id' and 'callback_token'.
     # The content will be a list with index '0' that's the value of the DmApiRv
     # 'success' variable and, at index '1', the original response message json().
-    # The Job callback token will be squonk_job_info[0]['callback_token']
+    # The Job callback token will be squonk_job_info[1]['callback_token']
     squonk_job_info = models.JSONField(encoder=DjangoJSONEncoder, null=True)
     # 'squonk_url_ext' is a Squonk UI URL to obtain information about the
     # running instance. It's essentially the Squonk URL with the instance ID appended.
@@ -1202,5 +1202,3 @@ class JobRequest(models.Model):
     class Meta:
         db_table = 'viewer_jobrequest'
 # End of Squonk Job Tables
-
-

--- a/viewer/squonk_job_file_upload.py
+++ b/viewer/squonk_job_file_upload.py
@@ -138,17 +138,27 @@ def process_compound_set_file(jr_id,
 
     logger.info('Processing job compound file (%s)...', jr_id)
 
+    logger.info("Squonk transition_time='%s'", transition_time)
+    logger.info("Squonk job_output_path='%s'", job_output_path)
+    logger.info("Squonk job_output_filename='%s'", job_output_filename)
+
     jr = JobRequest.objects.get(id=jr_id)
 
-    # The callback token (required to make Squonk API calls from the callback)
-    # and instance ID are in JobRequest.
+    # The callback token is required to make Squonk API calls from the callback context
     jr_job_info_msg = jr.squonk_job_info[1]
-    token = jr_job_info_msg.get('callback_token')
-    instance_id = jr_job_info_msg.get('instance_id')
-    logger.info("Squonk API token=%s", token)
-    logger.info("Squonk API instance_id=%s", instance_id)
+    callback_token = jr_job_info_msg.get('callback_token')
+    logger.info("Squonk API callback_token=%s", callback_token)
 
-    logger.info("Expecting Squonk path='%s'", job_output_path)
+    # The Squonk instance that ran the Job can be found
+    # at the end of the jr.squonk_url_ext field.
+    instance_id = ''
+    if jr.squonk_url_ext:
+        i_id = jr.squonk_url_ext.split('/')[-1]
+        if i_id.startswith('instance-'):
+            instance_id = i_id
+            logger.info("Squonk instance_id='%s'", instance_id)
+        else:
+            logger.warning("jr.squonk_url_ext does not contain an instance ID")
 
     # Do we need to create the upload path?
     # This is used for this 'job' and is removed when the upload is complete
@@ -182,7 +192,7 @@ def process_compound_set_file(jr_id,
     logger.info("Expecting Squonk job_output_param_filename='%s'...",
                 job_output_param_filename)
     result = DmApi.get_unmanaged_project_file_with_token(
-        token=token,
+        token=callback_token,
         project_id=jr.squonk_project,
         project_path=job_output_path,
         project_file=job_output_param_filename,
@@ -197,7 +207,7 @@ def process_compound_set_file(jr_id,
         logger.info("Expecting Squonk job_output_filename='%s'...",
                     job_output_filename)
         result = DmApi.get_unmanaged_project_file_with_token(
-            token=token,
+            token=callback_token,
             project_id=jr.squonk_project,
             project_path=job_output_path,
             project_file=job_output_filename,
@@ -209,12 +219,13 @@ def process_compound_set_file(jr_id,
         else:
             # Both files pulled back.
             got_all_files = True
-            # Delete the callback token, which is no-longer needed.
-            # Don't care if this fails - the token will expire automatically
-            # after a period of time.
-#            _ = DmApi.delete_instance_token(
-#                instance_id=instance_id,
-#                token=token)
+#            if instance_id:
+#                # Delete the callback token, which is no-longer needed.
+#                # Don't care if this fails - the token will expire automatically
+#                # after a period of time.
+#                _ = DmApi.delete_instance_token(
+#                    instance_id=instance_id,
+#                    token=callback_token)
 
     if not got_all_files:
         logger.warning('Not processing. Either %s or %s is missing',

--- a/viewer/squonk_job_request.py
+++ b/viewer/squonk_job_request.py
@@ -17,7 +17,7 @@ from viewer.models import ( Target,
                             Snapshot,
                             JobRequest,
                             JobFileTransfer )
-from viewer.utils import get_https_host
+from viewer.utils import create_squonk_job_request_url, get_https_host
 
 logger = logging.getLogger(__name__)
 
@@ -191,4 +191,9 @@ def create_squonk_job(request):
     logger.info('+ SUCCESS. Job "%s" started (job_instance_id=%s job_task_id=%s)',
                 job_name, job_instance_id, job_task_id)
 
-    return job_request.id, job_request.squonk_url_ext
+    # Manufacture the Squonk URL (actually set in the callback)
+    # so the front-end can use it immediately (we cannot set the JobRequest
+    # `squonk_url_ext` here as it introduces a race-condition with the callback logic).
+    squonk_url_ext = create_squonk_job_request_url(job_instance_id)
+
+    return job_request.id, squonk_url_ext

--- a/viewer/utils.py
+++ b/viewer/utils.py
@@ -16,6 +16,12 @@ from rdkit import Chem
 SDF_VERSION = 'ver_1.2'
 
 
+def create_squonk_job_request_url(instance_id):
+    """Creates the Squonk Instance API url from an instance ID (UUID).
+    """
+    return settings.SQUONK2_INSTANCE_API + str(instance_id)
+
+
 def create_media_sub_directory(sub_directory):
     """Creates a directory (or directories) in the MEDIA directory,
     returning the full path.
@@ -133,4 +139,3 @@ def get_https_host(request):
     Note that this link will not work on local
     """
     return settings.SECURE_PROXY_SSL_HEADER[1] + '://' + request.get_host()
-

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -36,6 +36,7 @@ from celery.result import AsyncResult
 from api.security import ISpyBSafeQuerySet
 
 from api.utils import get_params, get_highlighted_diffs
+from viewer.utils import create_squonk_job_request_url
 
 from viewer.models import (
     Molecule,
@@ -3422,15 +3423,15 @@ class JobCallBackView(viewsets.ModelViewSet):
                         code, status)
             return HttpResponse(status=204)
 
-        # This is now a chance to set the squonk_url_ext using the instance ID
+        # This is now a chance to safely set the squonk_url_ext using the instance ID
         # present in the callback (if it's not already set). The instance is
         # placed at the end of the string, and is expected to be found
-        # by process_compound_set_file() whcih loads the output file back
+        # by process_compound_set_file() which loads the output file back
         # into Fragalysis
         if not jr.squonk_url_ext:
-            jr.squonk_url_ext = settings.SQUONK2_INSTANCE_API + str(request.data['instance_id'])
+            jr.squonk_url_ext = create_squonk_job_request_url(request.data['instance_id'])
             logger.info("Setting jr.squonk_url_ext='%s'", jr.squonk_url_ext)
-            
+
         # Update the state transition time,
         # assuming UTC.
         transition_time = request.data.get('state_transition_time')

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -3422,6 +3422,15 @@ class JobCallBackView(viewsets.ModelViewSet):
                         code, status)
             return HttpResponse(status=204)
 
+        # This is now a chance to set the squonk_url_ext using the instance ID
+        # present in the callback (if it's not already set). The instance is
+        # placed at the end of the string, and is expected to be found
+        # by process_compound_set_file() whcih loads the output file back
+        # into Fragalysis
+        if not jr.squonk_url_ext:
+            jr.squonk_url_ext = settings.SQUONK2_INSTANCE_API + str(request.data['instance_id'])
+            logger.info("Setting jr.squonk_url_ext='%s'", jr.squonk_url_ext)
+            
         # Update the state transition time,
         # assuming UTC.
         transition_time = request.data.get('state_transition_time')
@@ -3447,7 +3456,7 @@ class JobCallBackView(viewsets.ModelViewSet):
             logger.info('Setting job FINISH datetime (%s)', transition_time)
             jr.job_finish_datetime = transition_time_utc
 
-        # Save - before going further.
+        # Save the JobRequest record before going further.
         jr.save()
 
         if status != 'SUCCESS':


### PR DESCRIPTION
This fixes a race-condition executing Job in Squonk.

The JobRequest record can be disturbed by concurrent access form the callback.
The fix ensures the JobRequest record is safe to use from the callback context.

Tested today (10 Jan, 14:40) by Boris.