### PR TITLE
Fix for GetProp error

### DIFF
--- a/viewer/cset_upload.py
+++ b/viewer/cset_upload.py
@@ -447,13 +447,28 @@ class MolOps:
 
 
 def blank_mol_vals(sdf_file):
+    """Returns the submitter name, method and version (_Name) if present.
+    If not present the corresponding values are empty strings.
+    """
     suppl = Chem.SDMolSupplier(sdf_file)
+    if not suppl:
+        return '', '', ''
     # print('%d mols detected (including blank mol)' % (len(suppl),))
     blank_mol = suppl[0]
+    if not blank_mol:
+        return '', '', ''
 
     # Get submitter name/info for passing into upload to get unique name
-    submitter_name = blank_mol.GetProp('submitter_name')
-    submitter_method = blank_mol.GetProp('method')
-    version = blank_mol.GetProp('_Name')
+    submitter_name = ''
+    if blank_mol.HasProp('submitter_name'):
+        submitter_name = blank_mol.GetProp('submitter_name')
+
+    submitter_method = ''
+    if blank_mol.HasProp('method'):
+        submitter_method = blank_mol.GetProp('method')
+
+    version = ''
+    if blank_mol.HasProp('_Name'):
+        version = blank_mol.GetProp('_Name')
 
     return submitter_name, submitter_method, version

--- a/viewer/tasks.py
+++ b/viewer/tasks.py
@@ -323,7 +323,10 @@ def validate_compound_set(task_params):
     for m in other_mols:
         if m:
             validate_dict = check_mol_props(m, validate_dict)
-            validate_dict = check_name_characters(m.GetProp('_Name'), validate_dict)
+            molecule_name = ''
+            if m.HasProp('_Name'):
+                molecule_name = m.GetProp('_Name')
+            validate_dict = check_name_characters(molecule_name, validate_dict)
             # validate_dict = check_pdb(m, validate_dict, target, zfile)
             validate_dict = check_refmol(m, validate_dict, target)
             validate_dict = check_field_populated(m, validate_dict)

--- a/viewer/tasks.py
+++ b/viewer/tasks.py
@@ -244,10 +244,6 @@ def validate_compound_set(task_params):
     # print('%d mols detected (including blank mol)' % (len(suppl),))
     blank_mol = suppl[0]
 
-    # Get submitter name/info for passing into upload to get unique name
-    submitter_name = blank_mol.GetProp('submitter_name')
-    submitter_method = blank_mol.GetProp('method')
-
     if blank_mol is None:
         validate_dict = add_warning(molecule_name='Blank Mol',
                                     field='N/A',
@@ -260,6 +256,9 @@ def validate_compound_set(task_params):
         logger.warning('validate_compound_set() EXIT'
                        ' user_id=%s sdf_file=%s validated=False',
                        user_id, sdf_file)
+        # Can't get submitter name or method when there is now mol
+        submitter_name = ''
+        submitter_method = ''
         return (validate_dict, validated, sdf_file, target, zfile,
                 submitter_name, submitter_method)
 
@@ -295,7 +294,10 @@ def validate_compound_set(task_params):
             props = [key for key in list(mol.GetPropsAsDict().keys())]
             diff_list = np.setdiff1d(props, unique_props)
             for diff in diff_list:
-                add_warning(molecule_name=mol.GetProp('_Name'),
+                molecule_name = 'Unknown (no _Name property)'
+                if mol.HasProp('_Name'):
+                    molecule_name = mol.GetProp('_Name')
+                add_warning(molecule_name=molecule_name,
                             field='property (missing)',
                             warning_string=f'{diff} property is missing from this molecule',
                             validate_dict=validate_dict)


### PR DESCRIPTION
This fixes the initial error but indicates that: -

a) the molecule is poorly formatted
b) there is a lot assumption in the exiting code that GetProp() works.

Fixing b throughout the code is a huge undertaking (and impacts on the chain of calls that would have to handle these errors - e.g. the code was designed with this assumption). Consequently, as fixing everything would probably add very little value at this stage only the immediate problem has been addressed.