### PR TITLE
Staging build now uses f/e staging branch

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -64,7 +64,7 @@ env:
   #   For Jobs conditional on the presence of a secret see this Gist...
   #   https://gist.github.com/jonico/24ffebee6d2fa2e679389fac8aef50a3
   BE_NAMESPACE: xchem
-  FE_BRANCH: production
+  FE_BRANCH: staging
   FE_NAMESPACE: xchem
   STACK_BRANCH: master
   STACK_GITHUB_NAMESPACE: xchem


### PR DESCRIPTION
A request from Boris to improve the turn-around of staging builds.
Instead of staging builds on the B/E from using the F/E `production`, staging builds now use the F/E `staging` branch.