### PR TITLE
POST to download_structures now requires authentication

### DIFF
--- a/viewer/views.py
+++ b/viewer/views.py
@@ -2993,6 +2993,12 @@ class DownloadStructures(ISpyBSafeQuerySet):
     def create(self, request):
         """Method to handle POST request
         """
+        # Only authenticated users can transfer files to sqonk
+        user = self.request.user
+        if not user.is_authenticated:
+            content = {'Only authenticated users can download structures'}
+            return Response(content, status=status.HTTP_403_FORBIDDEN)
+
         logger.info('+ DownloadStructures.post')
 
         # Clear up old existing files


### PR DESCRIPTION
- Now only users that are logged-in can download structures
- This matches the rule that only authenticated users can upload