### PR TITLE
A number of loggers now have a default of INFO (were WARNING)

### DIFF
--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -389,13 +389,13 @@ if not DISABLE_LOGGING_FRAMEWORK:
             'asyncio': {
                 'level': 'WARNING'},
             'celery': {
-                'level': 'WARNING'},
+                'level': 'INFO'},
             'django': {
-                'level': 'WARNING'},
+                'level': 'INFO'},
             'mozilla_django_oidc': {
-                'level': 'WARNING'},
+                'level': 'INFO'},
             'urllib3': {
-                'level': 'WARNING'},
+                'level': 'INFO'},
             'paramiko': {
                 'level': 'WARNING'}},
         'root': {


### PR DESCRIPTION
This wil help identify important information in frameworks like: -

- celery
- django
- mozilla_django_oidc- urllib3
