### PR TITLE
Fix for celery warnings

### DIFF
--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -86,14 +86,12 @@ REST_FRAMEWORK = {
 }
 
 # CELERY STUFF
+CELERY_ACCEPT_CONTENT = ['application/json']
+CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 CELERY_BROKER_URL = os.environ.get('CELERY_BROKER_URL', 'redis://localhost:6379')
 CELERY_RESULT_BACKEND = os.environ.get('CELERY_RESULT_BACKEND', 'redis://localhost:6379')
-CELERY_ACCEPT_CONTENT = ['application/json']
 CELERY_TASK_ALWAYS_EAGER = os.environ.get('CELERY_TASK_ALWAYS_EAGER', 'False').lower() in ['true', 'yes']
-CELERY_TASK_SERIALIZER = 'json'
-CELERY_RESULT_SERIALIZER = 'json'
-# This is to stop Celery overwriting the Django logging defaults.
-# CELERYD_HIJACK_ROOT_LOGGER = False
+CELERY_WORKER_HIJACK_ROOT_LOGGER = False
 
 # This can be injected as an ENV var
 NEOMODEL_NEO4J_BOLT_URL = os.environ.get(
@@ -402,4 +400,4 @@ if not DISABLE_LOGGING_FRAMEWORK:
                 'level': 'WARNING'}},
         'root': {
             'level': LOGGING_FRAMEWORK_ROOT_LEVEL,
-            'handlers': ['rotating']}}
+            'handlers': ['console', 'rotating']}}

--- a/launch-stack.sh
+++ b/launch-stack.sh
@@ -34,7 +34,6 @@ echo "Preparing logging..."
 touch /srv/logs/gunicorn.log
 touch /srv/logs/access.log
 touch /code/logs/logfile.log
-tail -n 0 -f /code/logs/*.log &
 
 echo "Starting Gunicorn..."
 gunicorn fragalysis.wsgi:application \


### PR DESCRIPTION
- Use of CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP to silence celery warnings
- CELERY_WORKER_HIJACK_ROOT_LOGGER to allow use of fragalysis logger
- Removed tail from launch-stack.sh