### PR TITLE
Adds 'legacy_url' to DJANGO_CONTEXT

### DIFF
--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -354,6 +354,11 @@ DISCOURSE_API_KEY = os.environ.get("DISCOURSE_API_KEY")
 # dedicated Discourse server.
 DISCOURSE_DEV_POST_SUFFIX = os.environ.get("DISCOURSE_DEV_POST_SUFFIX", '')
 
+# An optional URL that identifies the URL to a prior stack.
+# If set, it's typically something like "https://fragalysis.diamond.ac.uk".
+# It can be blank, indicating there is no legacy service.
+LEGACY_URL = os.environ.get("LEGACY_URL", "")
+
 SQUONK2_MEDIA_DIRECTORY = "fragalysis-files"
 SQUONK2_INSTANCE_API = "data-manager-ui/results/instance/"
 

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -210,6 +210,10 @@ def react(request):
 
     context = {}
 
+    # Legacy URL (a n optional prior stack)
+    # May be blank ('')
+    context['legacy_url'] = settings.LEGACY_URL
+
     # Is the Squonk2 Agent configured?
     logger.info("Checking whether Squonk2 is configured...")
     sq2_rv = _SQ2A.configured()


### PR DESCRIPTION
- Settings picks up the environment variable `LEGACY_URL`
- Default is blank (`''`)
- Value is always passed to the f.e via the `DJANGO_CONTEXT`