### PR TITLE
ref-url and rationale rules

### DIFF
--- a/viewer/cset_upload.py
+++ b/viewer/cset_upload.py
@@ -32,6 +32,7 @@ from viewer.models import (
     TextScoreValues,
     User,
 )
+from viewer.utils import is_url, word_count
 
 
 def dataType(a_str: str) -> str:
@@ -381,12 +382,15 @@ class MolOps:
         computed_molecule.name = name
         computed_molecule.smiles = smiles
         # Extract possible reference URL and Rationale
-        computed_molecule.ref_url = (
+        # URLs have to be valid URLs and rationals must contain more than one word
+        ref_url: Optional[str] = (
             mol.GetProp('ref_url') if mol.HasProp('ref_url') else None
         )
-        computed_molecule.rationale = (
+        computed_molecule.ref_url = ref_url if is_url(ref_url) else None
+        rationale: Optional[str] = (
             mol.GetProp('rationale') if mol.HasProp('rationale') else None
         )
+        computed_molecule.rationale = rationale if word_count(rationale) > 1 else None
         # To void the error
         #   needs to have a value for field "id"
         #   before this many-to-many relationship can be used.

--- a/viewer/tests/test_utils.py
+++ b/viewer/tests/test_utils.py
@@ -11,6 +11,8 @@ from viewer.utils import (
     create_squonk_job_request_url,
     delete_media_sub_directory,
     get_https_host,
+    is_url,
+    word_count,
 )
 
 
@@ -66,3 +68,30 @@ class ViewerUtilsTestCase(SimpleTestCase):
         request_mock.get_host.return_value = "example.com"
         result = get_https_host(request_mock)
         self.assertEqual(result, "https://example.com")
+
+    def test_is_url(self):
+        self.assertTrue(is_url("https://example.com"))
+        self.assertTrue(is_url("http://example.com"))
+        self.assertTrue(is_url("ftp://example.com"))
+        self.assertTrue(is_url("ftps://example.com"))
+        self.assertTrue(is_url("sftp://example.com"))
+        self.assertTrue(is_url("ssh://example.com"))
+        self.assertTrue(is_url("file://example.com"))
+        self.assertTrue(is_url("mailto://example.com"))
+        self.assertTrue(is_url("telnet://example.com"))
+        self.assertTrue(is_url("gopher://example.com"))
+        self.assertTrue(is_url("wais://example.com"))
+        self.assertTrue(is_url("ldap://example.com"))
+        self.assertTrue(is_url("news://example.com"))
+        self.assertTrue(is_url("nntp://example.com"))
+        self.assertTrue(is_url("prospero://example.com"))
+        # SOme failures...
+        self.assertFalse(is_url("/data/blob.html"))
+        self.assertFalse(is_url(532))
+        self.assertFalse(is_url(None))
+
+    def test_word_count(self):
+        self.assertEquals(2, word_count("Hello world"))
+        self.assertEquals(1, word_count("Hello") == 1)
+        self.assertEquals(0, word_count("") == 0)
+        self.assertEquals(0, word_count(None) == 0)

--- a/viewer/tests/test_utils.py
+++ b/viewer/tests/test_utils.py
@@ -92,6 +92,6 @@ class ViewerUtilsTestCase(SimpleTestCase):
 
     def test_word_count(self):
         self.assertEquals(2, word_count("Hello world"))
-        self.assertEquals(1, word_count("Hello") == 1)
-        self.assertEquals(0, word_count("") == 0)
-        self.assertEquals(0, word_count(None) == 0)
+        self.assertEquals(1, word_count("Hello"))
+        self.assertEquals(0, word_count(""))
+        self.assertEquals(0, word_count(None))

--- a/viewer/utils.py
+++ b/viewer/utils.py
@@ -7,6 +7,8 @@ import fnmatch
 import os
 import shutil
 from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
 
 from django.conf import settings
 from rdkit import Chem
@@ -14,6 +16,19 @@ from rdkit import Chem
 # Set .sdf file format version
 # Used at the start of every SDF file.
 SDF_VERSION = 'ver_1.2'
+
+
+def is_url(url: Optional[str]) -> bool:
+    try:
+        result = urlparse(url)
+        return all([result.scheme, result.netloc])
+    except ValueError:
+        return False
+
+
+def word_count(text: Optional[str]) -> int:
+    """Returns an 'approximate' word count."""
+    return len(text.split()) if text else 0
 
 
 def create_squonk_job_request_url(instance_id):

--- a/viewer/utils.py
+++ b/viewer/utils.py
@@ -22,7 +22,7 @@ def is_url(url: Optional[str]) -> bool:
     try:
         result = urlparse(url)
         return all([result.scheme, result.netloc])
-    except ValueError:
+    except (ValueError, AttributeError):
         return False
 
 


### PR DESCRIPTION
- ref-url must be a URL
- rationale must contain at least 2 words