### PR TITLE
fix: zip-file only cleared if file removed. Adds extra log

### DIFF
--- a/viewer/models.py
+++ b/viewer/models.py
@@ -1104,8 +1104,9 @@ class DownloadLinks(models.Model):
         return str(self.file_url)
 
     def __repr__(self) -> str:
-        return "<DownloadLinks %r %r %r %r>" % (
+        return "<DownloadLinks %r %r %r %r %r>" % (
             self.id,
+            self.zip_file,
             self.file_url,
             self.user,
             self.target,


### PR DESCRIPTION
- Mainly log changes to 'check_download_links()'
- Use of 'first()' to avoid constant use of '[0]' in DownloadLinks query
- 'maintain_download_links()' now only cleared zip_file if the file_url can be (or has been) deleted
- DownloadLinks model __repr__ mow includes zip_file flag