### PR TITLE
Download logic refactoring

### DIFF
--- a/api/remote_ispyb_connector.py
+++ b/api/remote_ispyb_connector.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 import time
 import traceback
@@ -64,6 +65,7 @@ class SSHConnector(Connector):
     ):
         sshtunnel.SSH_TIMEOUT = 10.0
         sshtunnel.TUNNEL_TIMEOUT = 10.0
+        sshtunnel.DEFAULT_LOGLEVEL = logging.CRITICAL
         self.conn_inactivity = int(self.conn_inactivity)
 
         self.server = sshtunnel.SSHTunnelForwarder(

--- a/api/security.py
+++ b/api/security.py
@@ -279,9 +279,8 @@ class ISpyBSafeQuerySet(viewsets.ReadOnlyModelViewSet):
                 logger.info("Getting proposals from ISPyB...")
                 proposals = self.get_proposals_for_user_from_ispyb(user)
             else:
-                logger.info(
-                    "No proposals (user %s is not authenticated)", user.username
-                )
+                username = user.username or "UNKNOWN"
+                logger.info("No proposals (user '%s' is not authenticated)", username)
         else:
             logger.info("Getting proposals from Django...")
             proposals = self.get_proposals_for_user_from_django(user)

--- a/viewer/download_structures.py
+++ b/viewer/download_structures.py
@@ -177,15 +177,12 @@ def _read_and_patch_molecule_name(path, molecule_name=None):
 
     logger.debug('Patching MOL/SDF "%s" molecule_name=%s', path, molecule_name)
 
-    name = molecule_name
-    if not name:
-        # No molecule name provided.
-        # The name will be set from file name
-        # (without path prefix and the extension)
-        # of the cleaned-up name.
-        # e.g. the name of 'media/sdfs/Mpro-x3351_0A_rtEVbqf.sdf'
-        # is 'Mpro-x3351_0A'.
-        name = os.path.splitext(clean_filename(path))[0]
+    # The name will be set from file name
+    # (without path prefix and the extension)
+    # of the cleaned-up name.
+    # e.g. the name of 'media/sdfs/Mpro-x3351_0A_rtEVbqf.sdf'
+    # is 'Mpro-x3351_0A'.
+    name = molecule_name or os.path.splitext(clean_filename(path))[0]
 
     # Now read the file, checking the first line
     # and setting it to the molecule name if it's blank.
@@ -193,9 +190,7 @@ def _read_and_patch_molecule_name(path, molecule_name=None):
     # which we eventually return to the caller.
     content = ''
     with open(path, 'r', encoding='utf-8') as f_in:
-        # First line (stripped)
-        first_line = f_in.readline().strip()
-        if first_line:
+        if first_line := f_in.readline().strip():
             content += first_line + '\n'
         else:
             content += name + '\n'
@@ -478,9 +473,7 @@ def _create_structures_zip(target, zip_contents, file_url, original_search, host
     # add sdf files to a file called {target}_combined.sdf.
     combined_sdf_file = None
     if zip_contents['molecules']['single_sdf_file'] is True:
-        combined_sdf_file = os.path.join(
-            download_path, '{}_combined.sdf'.format(target.title)
-        )
+        combined_sdf_file = os.path.join(download_path, f'{target.title}_combined.sdf')
         logger.info('combined_sdf_file=%s', combined_sdf_file)
 
     with zipfile.ZipFile(file_url, 'w', zipfile.ZIP_DEFLATED) as ziparchive:
@@ -671,9 +664,8 @@ def get_download_params(request):
     protein_params = {}
     for param in protein_param_flags:
         protein_params[param] = False
-        if param in request.data:
-            if request.data[param] == True or request.data[param] == 'true':
-                protein_params[param] = True
+        if param in request.data and request.data[param] in [True, 'true']:
+            protein_params[param] = True
 
     # other_params = {'sdf_info': request.data['sdf_info'],
     #                 'single_sdf_file': request.data['single_sdf_file'],
@@ -682,14 +674,14 @@ def get_download_params(request):
     other_params = {}
     for param in other_param_flags:
         other_params[param] = False
-        if param in request.data:
-            if request.data[param] == True or request.data[param] == 'true':
-                other_params[param] = True
+        if param in request.data and request.data[param] in [True, 'true']:
+            other_params[param] = True
 
     static_link = False
-    if 'static_link' in request.data:
-        if request.data['static_link'] is True or request.data['static_link'] == 'true':
-            static_link = True
+    if 'static_link' in request.data and (
+        request.data['static_link'] is True or request.data['static_link'] == 'true'
+    ):
+        static_link = True
 
     return protein_params, other_params, static_link
 
@@ -716,9 +708,7 @@ def create_or_return_download_link(request, target, site_observations):
 
     # Log the provided SiteObservations
     num_given_site_obs = site_observations.count()
-    site_ob_repr = ""
-    for site_ob in site_observations:
-        site_ob_repr += "%r " % site_ob
+    site_ob_repr = "".join("%r " % site_ob for site_ob in site_observations)
     logger.debug(
         'Given %s SiteObservation records: %r', num_given_site_obs, site_ob_repr
     )

--- a/viewer/download_structures.py
+++ b/viewer/download_structures.py
@@ -73,7 +73,7 @@ zip_template = {
 # where missing SD files are written.
 # The SD files are constructed from the molecule 'sdf_info' field
 # (essentially MOL-file text) when the 'sdf_file' field is blank.
-_MISSING_SDF_DIRECTORY = 'missing-sdfs'
+_MISSING_SDF_DIRECTORY = 'missing_sdfs'
 _MISSING_SDF_PATH = os.path.join(settings.MEDIA_ROOT, _MISSING_SDF_DIRECTORY)
 
 _ERROR_FILE = 'errors.csv'

--- a/viewer/models.py
+++ b/viewer/models.py
@@ -1083,6 +1083,7 @@ class DownloadLinks(models.Model):
     static_link = models.BooleanField(
         default=False, help_text="This preserves the proteins from the previous search"
     )
+    # TODO - zip_contents is no longer Used (A.Christie 2024-01-19)
     zip_contents = models.JSONField(
         encoder=DjangoJSONEncoder,
         null=True,
@@ -1097,6 +1098,7 @@ class DownloadLinks(models.Model):
         " plus the retention time"
         " (1 hour at the time of writing)",
     )
+    # TODO - zip_file is no longer Used (A.Christie 2024-01-19)
     zip_file = models.BooleanField(default=False)
     original_search = models.JSONField(encoder=DjangoJSONEncoder, null=True)
 


### PR DESCRIPTION
- Part of 1284
- DownloadLinks record now removed on expiry (unless static)
- zip_file and and zip_contents no longer used
- Downloads now simplified - cannot get a "someone else is downloading" errors
- Downloads exist or they do not. If they do the user is presented with the file.
- missign sdfs directroy rename
- supression of sshtunnel connection errors
- Dynamic download file timeout now 90 minutes
