### PR TITLE
Initial support for DEPLOYMENT_MODE

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -399,3 +399,7 @@ def pretty_request(request, *, tag='', print_body=False):
         f'{body}\n'
         '- REQUEST END'
     )
+
+
+def deployment_mode_is_production():
+    return settings.DEPLOYMENT_MODE == "PRODUCTION"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,7 @@ services:
     - .:/code/
     environment:
       AUTHENTICATE_UPLOAD: ${AUTHENTICATE_UPLOAD:-True}
+      DEPLOYMENT_MODE: 'development'
       POSTGRESQL_USER: postgres
       # Celery tasks need to run synchronously
       CELERY_TASK_ALWAYS_EAGER: 'True'

--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -240,6 +240,7 @@ OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS = int(TOKEN_EXPIRY_MINUTES) * 60
 # The deployment mode.
 # Controls the behaviour of the application (it's strictness to errors etc).
 # Typically one of "DEVELOPMENT" or "PRODUCTION".
+# see api.utils for the 'deployment_mode_is_production()' function.
 DEPLOYMENT_MODE = os.environ.get("DEPLOYMENT_MODE", "production").upper()
 
 ROOT_URLCONF = "fragalysis.urls"
@@ -456,9 +457,9 @@ if not DISABLE_LOGGING_FRAMEWORK:
             'api.security': {'level': 'INFO'},
             'asyncio': {'level': 'WARNING'},
             'celery': {'level': 'INFO'},
-            'django': {'level': 'INFO'},
-            'mozilla_django_oidc': {'level': 'INFO'},
-            'urllib3': {'level': 'INFO'},
+            'django': {'level': 'WARNING'},
+            'mozilla_django_oidc': {'level': 'WARNING'},
+            'urllib3': {'level': 'WARNING'},
             'paramiko': {'level': 'WARNING'},
         },
         'root': {

--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -237,6 +237,11 @@ TOKEN_EXPIRY_MINUTES = os.environ.get("OIDC_RENEW_ID_TOKEN_EXPIRY_MINUTES", "15"
 OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS = int(TOKEN_EXPIRY_MINUTES) * 60
 # Keycloak mozilla_django_oidc - Settings - End
 
+# The deployment mode.
+# Controls the behaviour of the application (it's strictness to errors etc).
+# Typically one of "DEVELOPMENT" or "PRODUCTION".
+DEPLOYMENT_MODE = os.environ.get("DEPLOYMENT_MODE", "production").upper()
+
 ROOT_URLCONF = "fragalysis.urls"
 
 STATIC_ROOT = os.path.join(PROJECT_ROOT, "static")


### PR DESCRIPTION
- By default (settings) this is `PRODUCTION`
- Controlled by `DEPLOYMENT_MODE` env variable (in playbooks `2024.4`)
- It forces XCA loader to be strict with regard to config's xca_version
- django, mozilla and urllib3 logging now WARNING (was INFO)
- Lack of target_name now put into the error report
- Adds DEPLOYMENT_MODE to compose file

Tested on local dev stack