### PR TITLE
Add DISABLE_RESTRICT_PROPOSALS_TO_MEMBERSHIP

### DIFF
--- a/api/security.py
+++ b/api/security.py
@@ -354,9 +354,10 @@ class ISpyBSafeQuerySet(viewsets.ReadOnlyModelViewSet):
         proposals = set()
         ispyb_user = settings.ISPYB_USER
         logger.debug(
-            "ispyb_user=%s restrict_to_membership=%s",
+            "ispyb_user=%s restrict_to_membership=%s (DISABLE_RESTRICT_PROPOSALS_TO_MEMBERSHIP=%s)",
             ispyb_user,
             restrict_to_membership,
+            settings.DISABLE_RESTRICT_PROPOSALS_TO_MEMBERSHIP,
         )
         if ispyb_user:
             if user.is_authenticated:
@@ -368,7 +369,10 @@ class ISpyBSafeQuerySet(viewsets.ReadOnlyModelViewSet):
 
         # We have all the proposals where the user has authority.
         # Add open/public proposals?
-        if not restrict_to_membership:
+        if (
+            not restrict_to_membership
+            or settings.DISABLE_RESTRICT_PROPOSALS_TO_MEMBERSHIP
+        ):
             proposals.update(self._get_open_proposals())
 
         # Return the set() as a list()

--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -464,6 +464,17 @@ if os.environ.get("AUTHENTICATE_UPLOAD") == "False":
 
 COMPUTED_SET_MEDIA_DIRECTORY: str = "computed_set_data"
 
+# The following (part of m2ms-1385) is used to prevent the
+# 'restrict-to-membership' check in security.py - something that is designed to prevent
+# uploading to public proposals unless the user is explicitly part of the proposal
+# (according to ISPyB). This variable is used to defeat this test for situations
+# when ISPyB is unavailable. It is not permitted when the DEPLOYMENT_MODE
+# is 'PRODUCTION
+DISABLE_RESTRICT_PROPOSALS_TO_MEMBERSHIP: bool = False
+if os.environ.get("DISABLE_RESTRICT_PROPOSALS_TO_MEMBERSHIP") == "True":
+    assert DEPLOYMENT_MODE != "PRODUCTION"
+    DISABLE_RESTRICT_PROPOSALS_TO_MEMBERSHIP = True
+
 # Discourse settings for API calls to Discourse Platform.
 DISCOURSE_PARENT_CATEGORY: str = "Fragalysis targets"
 DISCOURSE_USER: str = "fragalysis"

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -1579,7 +1579,7 @@ class UploadTargetExperiments(ISpyBSafeQuerySet):
             contact_email=contact_email,
             user_id=request.user.pk,
         )
-        logger.info("+ UploadTargetExperiments.create  got Celery id %s", task.task_id)
+        logger.info("+ UploadTargetExperiments.create got Celery id %s", task.task_id)
 
         url = reverse('viewer:task_status', kwargs={'task_id': task.task_id})
         # as it launches task, I think 202 is more appropriate


### PR DESCRIPTION
The **DISABLE_RESTRICT_PROPOSALS_TO_MEMBERSHIP** defeats the test in security.py. If this is set (to `"True"`) uploads against public proposals is permitted (if the **DEPLOYMENT_MODE** is not `production`)

This requires a new variable in the ansible playbook.