### PR TITLE
feat: add management commands to save and restore curated tags

### DIFF
--- a/viewer/management/commands/curated_tags.py
+++ b/viewer/management/commands/curated_tags.py
@@ -1,0 +1,27 @@
+from django.core.management.base import BaseCommand
+
+from viewer.utils import dump_curated_tags, restore_curated_tags
+
+
+class Command(BaseCommand):
+    help = "Dump or load curated tags"
+
+    def add_arguments(self, parser):
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument(
+            "--dump", metavar="<JSON file>", type=str, help="Save to file"
+        )
+        group.add_argument(
+            "--load",
+            metavar="JSON file>",
+            type=str,
+            help="Load file",
+        )
+
+    def handle(self, *args, **kwargs):
+        # Unused args
+        del args
+        if kwargs["dump"]:
+            dump_curated_tags(filename=kwargs["dump"])
+        if kwargs["load"]:
+            restore_curated_tags(filename=kwargs["load"])

--- a/viewer/utils.py
+++ b/viewer/utils.py
@@ -4,6 +4,8 @@ utils.py
 Collection of technical methods tidied up in one location.
 """
 import fnmatch
+import json
+import logging
 import os
 import shutil
 import tempfile
@@ -12,7 +14,22 @@ from typing import Dict, Optional
 from urllib.parse import urlparse
 
 from django.conf import settings
+from django.contrib.auth.models import User
+from django.db import IntegrityError, transaction
+from django.db.models import F
+from django.http import JsonResponse
 from rdkit import Chem
+
+from scoring.models import SiteObservationGroup, SiteObvsSiteObservationGroup
+
+from .models import (
+    SiteObservation,
+    SiteObservationTag,
+    SiteObvsSiteObservationTag,
+    Target,
+)
+
+logger = logging.getLogger(__name__)
 
 # Set .sdf file format version
 # Used at the start of every SDF file.
@@ -177,3 +194,214 @@ def handle_uploaded_file(path: Path, f):
     with open(path, "wb+") as destination:
         for chunk in f.chunks(4096):
             destination.write(chunk)
+
+
+def dump_curated_tags(filename: str) -> None:
+    # fmt: off
+    curated_tags = SiteObservationTag.objects.filter(
+        user__isnull=False,
+    ).annotate(
+        ann_target_name=F('target__title'),
+    )
+    users = User.objects.filter(
+        pk__in=curated_tags.values('user'),
+    )
+    siteobs_tag_group = SiteObvsSiteObservationTag.objects.filter(
+        site_obvs_tag__in=curated_tags.values('pk'),
+    ).annotate(
+        ann_site_obvs_longcode=F('site_observation__longcode')
+    )
+
+    site_obvs_group = SiteObservationGroup.objects.filter(
+        pk__in=curated_tags.values('mol_group'),
+    ).annotate(
+        ann_target_name=F('target__title'),
+    )
+
+    site_obvs_obvs_group = SiteObvsSiteObservationGroup.objects.filter(
+        site_obvs_group__in=site_obvs_group.values('pk'),
+    ).annotate(
+        ann_site_obvs_longcode=F('site_observation__longcode')
+    )
+    # fmt: on
+
+    result = {}
+    for qs in (
+        users,
+        curated_tags,
+        siteobs_tag_group,
+        site_obvs_group,
+        site_obvs_obvs_group,
+    ):
+        if qs.exists():
+            jq = JsonResponse(list(qs.values()), safe=False)
+            # have to pass through JsonResponse because that knows how
+            # to parse django db field types
+            data = json.loads(jq.content)
+            name = qs[0]._meta.label  # pylint: disable=protected-access
+            result[name] = data
+
+    with open(filename, 'w', encoding='utf-8') as writer:
+        writer.write(json.dumps(result, indent=4))
+
+
+def restore_curated_tags(filename: str) -> None:
+    with open(filename, 'r', encoding='utf-8') as reader:
+        content = json.loads(reader.read())
+
+    # models have to be saved in this order:
+    # 1) User
+    # 1) SiteObservationGroup  <- target
+    # 2) SiteObservationTag    <- target, user
+    # 3) SiteObvsSiteObservationGroup <- siteobvs
+    # 3) SiteObvsSiteObservationTag <- siteobvs
+
+    # takes a bit different approach with target and user - if user is
+    # missing, restores the user and continues with tags, if target is
+    # missing, skips the tag. This seems logical (at least at the time
+    # writing this): if target hasn't been added obviously user
+    # doesn't care about restoring the tags, but user might be
+    # legitimately missing (hasn't logged in yet, and somebody else is
+    # uploading the data)
+
+    targets = Target.objects.all()
+    site_observations = SiteObservation.objects.all()
+
+    try:
+        with transaction.atomic():
+            new_mol_groups_by_old_pk = {}
+            new_tags_by_old_pk = {}
+            new_users_by_old_pk = {}
+
+            user_data = content.get(
+                User._meta.label,  # pylint: disable=protected-access
+                [],
+            )
+            for data in user_data:
+                pk = data.pop('id')
+                try:
+                    user = User.objects.get(username=data['username'])
+                except User.DoesNotExist:
+                    user = User(**data)
+                    user.save()
+
+                new_users_by_old_pk[pk] = user
+
+            so_group_data = content.get(
+                SiteObservationGroup._meta.label,  # pylint: disable=protected-access
+                [],
+            )
+            for data in so_group_data:
+                try:
+                    target = targets.get(title=data['ann_target_name'])
+                except Target.DoesNotExist:
+                    logger.warning(
+                        'Tried to restore SiteObservationGroup for target that does not exist: %s',
+                        data['ann_target_name'],
+                    )
+                    continue
+
+                data['target'] = target
+                pk = data.pop('id')
+                del data['ann_target_name']
+                del data['target_id']
+                sog = SiteObservationGroup(**data)
+                sog.save()
+                new_mol_groups_by_old_pk[pk] = sog
+
+            so_tag_data = content.get(
+                SiteObservationTag._meta.label,  # pylint: disable=protected-access
+                [],
+            )
+            for data in so_tag_data:
+                try:
+                    target = targets.get(title=data['ann_target_name'])
+                except Target.DoesNotExist:
+                    logger.warning(
+                        'Tried to restore SiteObservationTag for target that does not exist: %s',
+                        data['ann_target_name'],
+                    )
+                    continue
+                data['target'] = target
+                pk = data.pop('id')
+                del data['ann_target_name']
+                del data['target_id']
+                if data['mol_group_id']:
+                    data['mol_group_id'] = new_mol_groups_by_old_pk[
+                        data['mol_group_id']
+                    ]
+                data['user'] = new_users_by_old_pk[data['user_id']]
+                del data['user_id']
+                tag = SiteObservationTag(**data)
+                try:
+                    with transaction.atomic():
+                        tag.save()
+                except IntegrityError:
+                    # this is an incredibly unlikely scenario where
+                    # tag already exists - user must have, before
+                    # restoring the tags, slightly edited an
+                    # auto-generated tag. I can update the curated
+                    # fields, but given they're both curated at this
+                    # point, I choose to do nothing, skip the tag
+                    logger.error(
+                        'Curated tag %s already exists, skipping restore', data['tag']
+                    )
+                    continue
+
+                new_tags_by_old_pk[pk] = tag
+
+            so_so_group_data = content.get(
+                SiteObvsSiteObservationGroup._meta.label,  # pylint: disable=protected-access
+                [],
+            )
+            for data in so_so_group_data:
+                try:
+                    site_obvs = site_observations.get(
+                        longcode=data['ann_site_obvs_longcode']
+                    )
+                except SiteObservation.DoesNotExist:
+                    logger.warning(
+                        'Tried to restore SiteObvsSiteObservationGroup for site_observation that does not exist: %s',
+                        data['ann_site_obvs_longcode'],
+                    )
+                    continue
+                site_obvs = site_observations.get(
+                    longcode=data['ann_site_obvs_longcode']
+                )
+                data['site_observation'] = site_obvs
+                del data['id']
+                del data['ann_site_obvs_longcode']
+                del data['site_observation_id']
+                data['site_obvs_group'] = new_mol_groups_by_old_pk[
+                    data['site_obvs_group']
+                ]
+                SiteObvsSiteObservationGroup(**data).save()
+
+            so_so_tag_data = content.get(
+                SiteObvsSiteObservationTag._meta.label,  # pylint: disable=protected-access
+                [],
+            )
+            for data in so_so_tag_data:
+                try:
+                    site_obvs = site_observations.get(
+                        longcode=data['ann_site_obvs_longcode']
+                    )
+                except SiteObservation.DoesNotExist:
+                    logger.warning(
+                        'Tried to restore SiteObvsSiteObservationGroup for site_observation that does not exist: %s',
+                        data['ann_site_obvs_longcode'],
+                    )
+                    continue
+                data['site_observation'] = site_obvs
+                del data['id']
+                del data['ann_site_obvs_longcode']
+                del data['site_observation_id']
+                data['site_obvs_tag'] = new_tags_by_old_pk.get(
+                    data['site_obvs_tag'], None
+                )
+                if data['site_obvs_tag']:
+                    # tag may be missing if not restored
+                    SiteObvsSiteObservationTag(**data).save()
+
+    except IntegrityError as exc:
+        logger.error(exc)


### PR DESCRIPTION
In app container either
`python manage.py curated_tags --dump tags.json`
or
`python manage.py curated_tags --load tags.json`