### PR TITLE
Copies Target proposals to new (RHS) Compounds

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -85,12 +85,11 @@ jobs:
       with:
         context: .
         tags: ${{ steps.vars.outputs.BE_NAMESPACE }}/fragalysis-backend:${{ env.GITHUB_REF_SLUG }}
-    - name: Test
-      run: >
-        docker-compose -f docker-compose.test.yml up
-        --build
-        --exit-code-from tests
-        --abort-on-container-exit
+    - name: Test (docker compose)
+      uses: hoverkraft-tech/compose-action@v2.0.1
+      with:
+        compose-file: ./docker-compose.test.yml
+        up-flags: --build --exit-code-from tests --abort-on-container-exit
       env:
         BE_NAMESPACE: ${{ steps.vars.outputs.BE_NAMESPACE }}
         BE_IMAGE_TAG: ${{ env.GITHUB_REF_SLUG }}

--- a/.github/workflows/build-production.yaml
+++ b/.github/workflows/build-production.yaml
@@ -134,12 +134,11 @@ jobs:
         tags: |
           ${{ steps.vars.outputs.BE_NAMESPACE }}/fragalysis-backend:${{ steps.vars.outputs.tag }}
           ${{ steps.vars.outputs.BE_NAMESPACE }}/fragalysis-backend:stable
-    - name: Test
-      run: >
-        docker-compose -f docker-compose.test.yml up
-        --build
-        --exit-code-from tests
-        --abort-on-container-exit
+    - name: Test (docker compose)
+      uses: hoverkraft-tech/compose-action@v2.0.1
+      with:
+        compose-file: ./docker-compose.test.yml
+        up-flags: --build --exit-code-from tests --abort-on-container-exit
       env:
         BE_NAMESPACE: ${{ steps.vars.outputs.BE_NAMESPACE }}
         BE_IMAGE_TAG: ${{ steps.vars.outputs.tag }}

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -154,12 +154,11 @@ jobs:
       with:
         context: .
         tags: ${{ steps.vars.outputs.BE_NAMESPACE }}/fragalysis-backend:${{ steps.vars.outputs.tag }}
-    - name: Test
-      run: >
-        docker-compose -f docker-compose.test.yml up
-        --build
-        --exit-code-from tests
-        --abort-on-container-exit
+    - name: Test (docker compose)
+      uses: hoverkraft-tech/compose-action@v2.0.1
+      with:
+        compose-file: ./docker-compose.test.yml
+        up-flags: --build --exit-code-from tests --abort-on-container-exit
       env:
         BE_NAMESPACE: ${{ steps.vars.outputs.BE_NAMESPACE }}
         BE_IMAGE_TAG: ${{ steps.vars.outputs.tag }}

--- a/viewer/cset_upload.py
+++ b/viewer/cset_upload.py
@@ -291,9 +291,17 @@ class MolOps:
             )
             # This is a new compound.
             # We must now set relationships to the Proposal that it applies to.
-            # (see m2ms-1485)
-            #
-            # FixMe
+            # We do this by copying the relationships from the Target.
+            num_target_proposals = len(target.project_id.all())
+            assert num_target_proposals > 0
+            if num_target_proposals > 1:
+                logger.warning(
+                    'Compound Target %s has more than one Proposal (%d)',
+                    target.title,
+                    num_target_proposals,
+                )
+            for project in target.project_set.all():
+                cpd.project_id.add(project)
             cpd.save()
         except MultipleObjectsReturned as exc:
             # NB! when processing new uploads, Compound is always

--- a/viewer/cset_upload.py
+++ b/viewer/cset_upload.py
@@ -289,6 +289,7 @@ class MolOps:
                 inchi_key=inchi_key,
                 current_identifier=name,
             )
+            cpd.save()
             # This is a new compound.
             # We must now set relationships to the Proposal that it applies to.
             # We do this by copying the relationships from the Target.

--- a/viewer/cset_upload.py
+++ b/viewer/cset_upload.py
@@ -303,7 +303,6 @@ class MolOps:
                 )
             for project in target.project_set.all():
                 cpd.project_id.add(project)
-            cpd.save()
         except MultipleObjectsReturned as exc:
             # NB! when processing new uploads, Compound is always
             # fetched by inchi_key, so this shouldn't ever create

--- a/viewer/cset_upload.py
+++ b/viewer/cset_upload.py
@@ -289,6 +289,11 @@ class MolOps:
                 inchi_key=inchi_key,
                 current_identifier=name,
             )
+            # This is a new compound.
+            # We must now set relationships to the Proposal that it applies to.
+            # (see m2ms-1485)
+            #
+            # FixMe
             cpd.save()
         except MultipleObjectsReturned as exc:
             # NB! when processing new uploads, Compound is always


### PR DESCRIPTION
- Cannot back-propagate so exiting RHS needs to be repaired
- It's an error to use a Target without any proposals (a data error?)
- A warning is issued (to the log) if Targets have more than one proposal