### PR TITLE
Add support for target_warning_message context variable

### DIFF
--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -630,6 +630,10 @@ SQUONK2_VERIFY_CERTIFICATES: str = os.environ.get("SQUONK2_VERIFY_CERTIFICATES",
 
 TARGET_LOADER_MEDIA_DIRECTORY: str = "target_loader_data"
 
+# A warning messages issued by the f/e.
+# Used, if set, to populate the 'target_warning_message' context variable
+TARGET_WARNING_MESSAGE: str = os.environ.get("TARGET_WARNING_MESSAGE", "")
+
 # The Target Access String (TAS) Python regular expression.
 # The Project title (the TAS) must match this expression to be valid.
 # See api/utils.py validate_tas() for the current implementation.

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -127,6 +127,9 @@ def react(request):
         if sq2_rv.success and check_squonk_active(request):
             context['squonk_ui_url'] = _SQ2A.get_ui_url()
 
+    if settings.TARGET_WARNING_MESSAGE:
+        context['target_warning_message'] = settings.TARGET_WARNING_MESSAGE
+
     return render(request, "viewer/react_temp.html", context)
 
 


### PR DESCRIPTION
- If the environment variable TARGET_WARNING_MESSAGE is set
  it is used to set the context target_warning_message
- Requires changes to the playbooks to be effective