### PR TITLE
Relaxes authentication for SessionProject

### DIFF
--- a/viewer/permissions.py
+++ b/viewer/permissions.py
@@ -53,13 +53,14 @@ class IsObjectProposalMember(permissions.BasePermission):
         else:
             # Only one proposal...
             object_proposals = [attr_value.title]
+        if not object_proposals:
+            raise PermissionDenied(
+                detail="Authority cannot be granted - the object is not a part of any Project"
+            )
         # Now we have the proposals the object belongs to
         # has the user been associated (in IPSpyB) with any of them?
-        if (
-            object_proposals
-            and not _ISPYB_SAFE_QUERY_SET.user_is_member_of_any_given_proposals(
-                user=request.user, proposals=object_proposals
-            )
+        if not _ISPYB_SAFE_QUERY_SET.user_is_member_of_any_given_proposals(
+            user=request.user, proposals=object_proposals
         ):
             raise PermissionDenied(
                 detail="Your authority to access this object has not been given"

--- a/viewer/serializers.py
+++ b/viewer/serializers.py
@@ -557,7 +557,7 @@ class SessionProjectReadSerializer(serializers.ModelSerializer):
 
 
 # (POST, PUT, PATCH)
-class SessionProjectWriteSerializer(ValidateProjectMixin, serializers.ModelSerializer):
+class SessionProjectWriteSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.SessionProject
         fields = '__all__'

--- a/viewer/serializers.py
+++ b/viewer/serializers.py
@@ -78,18 +78,19 @@ class ValidateProjectMixin:
         else:
             # Only one proposal...
             object_proposals = [project_obj.title]
+        if not object_proposals:
+            raise PermissionDenied(
+                detail="Authority cannot be granted - the object is not a part of any Project"
+            )
 
         # Now we have the proposals (Project titles) the object belongs to,
         # has the user been associated (in IPSpyB) with any of them?
         # We can always see (GET) objects that are open to the public.
         restrict_public = False if self.context['request'].method == 'GET' else True  # type: ignore [attr-defined]
-        if (
-            object_proposals
-            and not _ISPYB_SAFE_QUERY_SET.user_is_member_of_any_given_proposals(
-                user=user,
-                proposals=object_proposals,
-                restrict_public_to_membership=restrict_public,
-            )
+        if not _ISPYB_SAFE_QUERY_SET.user_is_member_of_any_given_proposals(
+            user=user,
+            proposals=object_proposals,
+            restrict_public_to_membership=restrict_public,
         ):
             raise PermissionDenied(
                 detail="Your authority to access this object has not been given"

--- a/viewer/serializers.py
+++ b/viewer/serializers.py
@@ -558,16 +558,6 @@ class SessionProjectReadSerializer(serializers.ModelSerializer):
 
 # (POST, PUT, PATCH)
 class SessionProjectWriteSerializer(ValidateProjectMixin, serializers.ModelSerializer):
-    # def validate_target(self, value):
-    #     user = self.context['request'].user
-    #     if not user or not user.is_authenticated:
-    #         raise serializers.ValidationError("You must be logged in to create objects")
-    #     if not _ISPYB_SAFE_QUERY_SET.user_is_member_of_target(user, value):
-    #         raise serializers.ValidationError(
-    #             "You have not been given access the object's Target"
-    #         )
-    #     return value
-
     class Meta:
         model = models.SessionProject
         fields = '__all__'

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -919,7 +919,6 @@ class SessionProjectView(
     queryset = models.SessionProject.objects.filter()
     filter_permissions = "target__project_id"
     filterset_fields = '__all__'
-    permission_classes = [IsObjectProposalMember]
 
     def get_serializer_class(self):
         if self.request.method in ['GET']:


### PR DESCRIPTION
- Behaves like Snapshots
- Also produces special error if the Target has no Projects