### PR TITLE
fix: log compound names when alignment is not found (issue 1495)

### DIFF
--- a/viewer/cset_upload.py
+++ b/viewer/cset_upload.py
@@ -447,7 +447,18 @@ class MolOps:
                 # find distances between corresponding atoms of the
                 # two conformers. if any one exceeds the _DIST_LIMIT,
                 # consider it to be a new ComputedMolecule
-                _, _, atom_map = Chem.rdMolAlign.GetBestAlignmentTransform(mol, kmol)
+                try:
+                    _, _, atom_map = Chem.rdMolAlign.GetBestAlignmentTransform(
+                        mol, kmol
+                    )
+                except RuntimeError as exc:
+                    msg = (
+                        f'Failed to find alignment between {k.molecule_name} '
+                        + f'and {mol.GetProp("original ID")}'
+                    )
+                    logger.error(msg)
+                    raise RuntimeError(msg) from exc
+
                 molconf = mol.GetConformer()
                 kmolconf = kmol.GetConformer()
                 small_enough = True


### PR DESCRIPTION
NB! Currently breaks on first fail, does not process the full list and report back all offending molecules. 