### PR TITLE
Fixed (probably) data loss on metadata.csv uploads (issue 1535)

### DIFF
--- a/viewer/tags.py
+++ b/viewer/tags.py
@@ -276,7 +276,13 @@ def load_tags_from_file(filename: str, target: Target) -> list[str]:  # type: ig
                 target=target,
             )
 
-            qs = SiteObservation.objects.filter(longcode__in=df['Long code'])
+            # fmt: off
+            qs = SiteObservation.filter_manager.by_target(
+                target=target,
+            ).filter(
+                longcode__in=df['Long code'],
+            )
+            # fmt: on
 
             alias_update = []
             for upload_name, alias in tag_aliases:


### PR DESCRIPTION
The problem was caused by faulty SiteObservation query, cases where observation longcode was the same between multiple targets are affected.