### PR TITLE
RESTRICTED_TAS_USERS_LIST now ignored in production

### DIFF
--- a/api/security.py
+++ b/api/security.py
@@ -19,6 +19,7 @@ from viewer.models import Project
 
 from .prometheus_metrics import PrometheusMetrics
 from .remote_ispyb_connector import SSHConnector
+from .utils import deployment_mode_is_production
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -35,7 +36,10 @@ def get_restricted_tas_user_proposal(user) -> set[str]:
     assert user
 
     response = set()
-    if settings.RESTRICTED_TAS_USERS_LIST:
+
+    # We ONLY permit the use of RESTRICTED_TAS_USERS
+    # when this is not a production deployment
+    if not deployment_mode_is_production() and settings.stack_restricted_tas_users:
         for item in settings.RESTRICTED_TAS_USERS_LIST:
             item_username, item_tas = item.split(':')
             if item_username == user.username:


### PR DESCRIPTION
This change prevents the security `get_restricted_tas_user_proposal(user)` function from returning anything if the deployment mode is `PRODUCTION`.  In production, proposals available to a user are limited exclusively to what is returned by ISpyB.