### PR TITLE
Avoid corruption of cached set

### DIFF
--- a/api/security.py
+++ b/api/security.py
@@ -357,7 +357,9 @@ class ISPyBSafeQuerySet(viewsets.ReadOnlyModelViewSet):
             len(cached_prop_ids),
             user.username,
         )
-        return cached_prop_ids
+        # We must return a copy of the set,
+        # the caller may alter it and it's a cached object.
+        return cached_prop_ids.copy()
 
     def _get_proposals_from_connector(self, user, conn):
         """


### PR DESCRIPTION
A reference to the cached set is returned to the caller. This exposes the cache to the user who can alter it. In order to avoid this risk a copy of the cached set is now returned. The user can alter its content but the original cache remains intact for any future calls.