### PR TITLE
Add initial support for "dynamic" documentation URLs [#1786]

### DIFF
--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -685,15 +685,15 @@ FE_IMAGE_TAG: str = os.environ.get("FE_IMAGE_TAG", "undefined")
 STACK_NAMESPACE: str = os.environ.get("STACK_NAMESPACE", "undefined")
 STACK_VERSION: str = os.environ.get("STACK_VERSION", "undefined")
 
-# Documentation URLs STack, F/E and B/E.
+# Documentation URLs Stack, F/E and B/E.
 #
-# If provided, the administrator provides a Python format string
-# that allows the b/e to insert the STACK_VERSION into it
+# If the administrator provides a Python format string
+# the B/E will insert the STACK_VERSION into it
 # using a built-in variable it creates ("stack_version").
 # For example if your documentation is version-based at the URL
 # "https://documentation/stack/2025.01.1/docs" you can provide the format string
-# "https://documentation/stack/{stack_version}/docs". You do not have tpo provide
-# a {stack_version} is the documentation is not version based.
+# "https://documentation/stack/{stack_version}/docs". You do not have to provide
+# a {stack_version} if the documentation is not version based.
 # The resultant string is exposed to the F/E via the context variable
 # (e.g. "stack_documentation_url").
 #
@@ -703,6 +703,11 @@ STACK_VERSION: str = os.environ.get("STACK_VERSION", "undefined")
 #   stack_version
 #   fe_image_tag
 #   be_image_tag
+# And are exposed via the context variables: -
+#
+#   stack_documentation_url
+#   fe_documentation_url
+#   be_documentation_url
 STACK_DOCUMENTATION_URL_FORMAT_STRING: str = os.environ.get(
     "STACK_DOCUMENTATION_URL_FORMAT_STRING", ""
 )

--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -685,6 +685,33 @@ FE_IMAGE_TAG: str = os.environ.get("FE_IMAGE_TAG", "undefined")
 STACK_NAMESPACE: str = os.environ.get("STACK_NAMESPACE", "undefined")
 STACK_VERSION: str = os.environ.get("STACK_VERSION", "undefined")
 
+# Documentation URLs STack, F/E and B/E.
+#
+# If provided, the administrator provides a Python format string
+# that allows the b/e to insert the STACK_VERSION into it
+# using a built-in variable it creates ("stack_version").
+# For example if your documentation is version-based at the URL
+# "https://documentation/stack/2025.01.1/docs" you can provide the format string
+# "https://documentation/stack/{stack_version}/docs". You do not have tpo provide
+# a {stack_version} is the documentation is not version based.
+# The resultant string is exposed to the F/E via the context variable
+# (e.g. "stack_documentation_url").
+#
+# There are separate URLs available for the Stack, F/E and B/E
+# that use the variables: -
+#
+#   stack_version
+#   fe_image_tag
+#   be_image_tag
+STACK_DOCUMENTATION_URL_FORMAT_STRING: str = os.environ.get(
+    "STACK_DOCUMENTATION_URL_FORMAT_STRING", ""
+)
+FE_DOCUMENTATION_URL_FORMAT_STRING: str = os.environ.get(
+    "FE_DOCUMENTATION_URL_FORMAT_STRING", ""
+)
+BE_DOCUMENTATION_URL_FORMAT_STRING: str = os.environ.get(
+    "BE_DOCUMENTATION_URL_FORMAT_STRING", ""
+)
 
 # XChem Align data format
 XCA_DATA_FORMAT_VERSION = "2.2"

--- a/viewer/templates/viewer/react_temp.html
+++ b/viewer/templates/viewer/react_temp.html
@@ -27,7 +27,10 @@
          user_present_on_discourse: {{ user_present_on_discourse|default:"false" }},
          discourse_host: '{{ discourse_host }}',
          squonk_available: {{ squonk_available }},
-         squonk_ui_url: '{{ squonk_ui_url }}'
+         squonk_ui_url: '{{ squonk_ui_url }}',
+         stack_documentation_url: '{{ stack_documentation_url }}',
+         fe_documentation_url: '{{ fe_documentation_url }}',
+         be_documentation_url: '{{ be_documentation_url }}'
      }
  {% else %}
      var DJANGO_CONTEXT = {
@@ -40,7 +43,10 @@
          pk: undefined,
          authenticated: false,
          discourse_available: {{ discourse_available }},
-         squonk_available: {{ squonk_available }}
+         squonk_available: {{ squonk_available }},
+         stack_documentation_url: '{{ stack_documentation_url }}',
+         fe_documentation_url: '{{ fe_documentation_url }}',
+         be_documentation_url: '{{ be_documentation_url }}'
      }
  {% endif %}
 

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -147,6 +147,30 @@ def react(request):
 
     context['target_warning_message'] = settings.TARGET_WARNING_MESSAGE
 
+    # If a DOCUMENTATION_URLs are defined
+    # add a URL to the context using the appropriate version.
+    context['stack_documentation_url'] = ''
+    context['fe_documentation_url'] = ''
+    context['be_documentation_url'] = ''
+    if settings.STACK_DOCUMENTATION_URL_FORMAT_STRING:
+        context[
+            'stack_documentation_url'
+        ] = settings.STACK_DOCUMENTATION_URL_FORMAT_STRING.format(
+            stack_version=settings.STACK_VERSION
+        )
+    if settings.FE_DOCUMENTATION_URL_FORMAT_STRING:
+        context[
+            'fe_documentation_url'
+        ] = settings.FE_DOCUMENTATION_URL_FORMAT_STRING.format(
+            fe_image_tag=settings.FE_IMAGE_TAG
+        )
+    if settings.STACK_DOCUMENTATION_URL_FORMAT_STRING:
+        context[
+            'be_documentation_url'
+        ] = settings.BE_DOCUMENTATION_URL_FORMAT_STRING.format(
+            be_image_tag=settings.BE_IMAGE_TAG
+        )
+
     render_template = "viewer/react_temp.html"
     logger.debug("Rendering %s with context=%s...", render_template, context)
     return render(request, render_template, context)


### PR DESCRIPTION
- Solution for #1786
- Documentation format strings can be provided in the environment variables: -
  - `STACK_DOCUMENTATION_URL_FORMAT_STRING` (exposed as `stack_documentation_url`)
  - `FE_DOCUMENTATION_URL_FORMAT_STRING` (exposed as `fe_documentation_url`)
  - `BE_DOCUMENTATION_URL_FORMAT_STRING` (exposed as `be_documentation_url`)
