### PR TITLE
Adjust migration 0128 to fix “rdkit” already exists error

### DIFF
--- a/viewer/migrations/0128_auto_20250516_1015.py
+++ b/viewer/migrations/0128_auto_20250516_1015.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
     # lots happening here..
     operations = [
         # install extension to postgres
-        migrations.RunSQL('create extension rdkit;'),
+        migrations.RunSQL('create extension if not exists rdkit;'),
         # models.py adds BinaryField, convert to appropriate rdkit mol type
         migrations.RunSQL(
             sql="""


### PR DESCRIPTION
This alters the migration that creates the rdkit extension to avoid a **“rdkit” already exists** error when running against a recovered production DB. In `0128_auto_20250516_1015.py` this...

```
migrations.RunSQL('create extension rdkit;')
```

becomes this...

```
migrations.RunSQL('create extension if not exists rdkit;')
```