### PR TITLE
Add file watcher to target media directory (issue 1609)

### DIFF
--- a/launch-stack.sh
+++ b/launch-stack.sh
@@ -5,6 +5,10 @@
 # -o (for option) pipefail exits on command pipe failures
 set -eo pipefail
 
+# part of debugging issue 1609, missing template protein
+echo "Starting media deletion watcher..."
+/code/filewatcher.sh &
+
 echo "Running migrations..."
 cd /code
 python manage.py migrate
@@ -57,7 +61,7 @@ gunicorn fragalysis.wsgi:application \
 
 # NB! this is probably a workaround for some other issue we haven't
 # discovered yet. It suddenly broke but right now seems to work in
-# firefox. Hopefully won't be necessary soon
+# firefox. 12Hopefully won't be necessary soon
 echo proxy_set_header X-Forwarded-Proto "${PROXY_FORWARDED_PROTO_HEADER:-https};"  >> /etc/nginx/frag_proxy_params
 
 echo "Testing nginx config..."

--- a/launch-worker.sh
+++ b/launch-worker.sh
@@ -5,6 +5,12 @@
 # -o (for option) pipefail exits on command pipe failures
 set -eo pipefail
 
+# part of debugging issue 1609, missing template protein
+if [ "${WATCH_MEDIA_DELETIONS:-false}" = "true" ]; then
+    echo "Starting media deletion watcher..."
+    /code/filewatcher.sh &
+fi
+
 CONCURRENCY=${WORKER_CONCURRENCY:-4}
 
 echo "Running celery (CONCURRENCY=${CONCURRENCY})..."


### PR DESCRIPTION
Watches for deletion events and logs them to target media directory/deletions-<pod name>.log