### PR TITLE
Extend tas-stats response

### DIFF
--- a/api/ta_auth_connector.py
+++ b/api/ta_auth_connector.py
@@ -22,11 +22,12 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 @dataclass
 class TasAuthVersionGetResponse:
-    """The TA authenticator version response."""
+    """The TA authenticator version response (including the base URL)."""
 
     version: str
     kind: str
     name: str
+    location: str = _URL_BASE
 
 
 @dataclass

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -3377,7 +3377,12 @@ class TASStatsView(viewsets.ViewSet):
 
         result = {
             "user": user.username,
-            "version": auth_version.kind,
+            "version": {
+                "kind": auth_version.kind,
+                "name": auth_version.name,
+                "version": auth_version.version,
+                "location": auth_version.location,
+            },
             "ping": ping.ping,
             "target_access": list(tas_set),
         }


### PR DESCRIPTION
Adds more information to "version": -

```json
"version": {
    "kind": "ISPyB",
    "name": "XChem Python FastAPI TAS Authenticator",
    "version": "1.4.4",
    "location": "http://auth.ta-authenticator.svc",
}
```