### PR TITLE
Fixes target loader quirks (issue 2022)

### DIFF
--- a/viewer/serializers.py
+++ b/viewer/serializers.py
@@ -990,6 +990,7 @@ class TargetExperimentReadSerializer(ValidateProjectMixin, serializers.ModelSeri
 class TargetExperimentWriteSerializer(serializers.ModelSerializer):
     target_access_string = serializers.CharField(label='Target Access String')
     file = serializers.FileField(required=False)
+    sha256checksum = serializers.CharField(required=False)
 
     def validate(self, data):
         """Verify TAS is correctly formed."""
@@ -1000,10 +1001,7 @@ class TargetExperimentWriteSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.ExperimentUpload
-        fields = (
-            'target_access_string',
-            'file',
-        )
+        fields = ('target_access_string', 'file', 'sha256checksum')
 
 
 class TargetExperimentValidateSerializer(serializers.ModelSerializer):

--- a/viewer/target_loader.py
+++ b/viewer/target_loader.py
@@ -3855,9 +3855,15 @@ def _move_and_save_target_experiment(target_loader):
         str(target_loader.raw_data.joinpath(target_loader.version_dir)),
         str(target_loader.abs_final_path),
     )
-    Path(target_loader.bundle_path).rename(
-        target_loader.abs_final_path.joinpath(target_loader.data_bundle)
-    )
+    final_bundle_path = target_loader.abs_final_path.joinpath(target_loader.data_bundle)
+    if final_bundle_path.exists():
+        # don't overwrite if user uses the same name
+        final_bundle_path = Path(
+            *final_bundle_path.parts[:-1],
+            f'{final_bundle_path.stem}_{target_loader.version_dir}{final_bundle_path.suffix}',
+        )
+
+    Path(target_loader.bundle_path).rename(final_bundle_path)
 
     set_directory_permissions(target_loader.abs_final_path, 0o755)
 

--- a/viewer/target_loader.py
+++ b/viewer/target_loader.py
@@ -3765,7 +3765,7 @@ def check_decompress_progress(process, archive_path, update, frequency=1.0):
 
 def load_target(
     data_bundle,
-    proposal_ref=None,
+    proposal_ref: str,
     user_id=None,
     task=None,
 ):

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -54,6 +54,7 @@ from viewer.target_loader import (
 )
 from viewer.utils import (
     CSV_TO_DICT_DOWNLOAD_ROOT,
+    calculate_sha256,
     create_csv_from_dict,
     create_squonk_job_request_url,
     handle_uploaded_file,
@@ -1762,6 +1763,19 @@ class UploadExperimentUploadView(viewsets.ViewSet):
         temp_path.mkdir(exist_ok=True)
         target_file = temp_path.joinpath(filename.name)
         handle_uploaded_file(target_file, filename)
+
+        if file_hash := serializer.validated_data.get('sha256checksum', None):
+            checksum = calculate_sha256(str(target_file))
+            if checksum != file_hash:
+                return Response(
+                    {
+                        "filename": [
+                            "Uploaded file checksum does not match the supplied checksum, "
+                            + "file was likely corrupt during the transfer.",
+                        ]
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
         celery_app = Celery("fragalysis")
         celery_app.config_from_object("django.conf:settings", namespace="CELERY")


### PR DESCRIPTION
Checks tarball integrity post-upload and ensures tarballs are not overwritten even if the user uses the same filename for multiple uploads.

NB! Needs to be synchronised with XCA release, otherwise breaks uploads.