### PR TITLE
Fix 403 (info is None) response from TaskStatusView

### DIFF
--- a/viewer/views.py
+++ b/viewer/views.py
@@ -1988,9 +1988,9 @@ class TaskStatusView(APIView):
                 messages = result.info.get('description', [])
             else:
                 # The result 'info' should be a 'dict' but suspected race conditions
-                # occasionally mean it's 'None'. Here we 'assume" the task has yet
-                # to be handled internally, so we log a warning and return an
-                # UNKNOWN status.
+                # occasionally mean it's 'None'. Here we assume the task has yet
+                # to be handled internally and info will be populated soon.
+                # For now we log a warning and return an UNKNOWN status.
                 logger.warning(
                     'AsyncResult info for %s is %s instead of dict',
                     task_id_str,

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -1964,6 +1964,7 @@ class TaskStatusView(APIView):
         del args, kwargs
 
         logger.debug("task_id=%s", task_id)
+        task_status = "UNKNOWN"
 
         # task_id is a UUID, but Celery expects a string
         task_id_str = str(task_id)
@@ -1983,19 +1984,24 @@ class TaskStatusView(APIView):
         messages = []
         if hasattr(result, 'info'):
             if isinstance(result.info, dict):
-                # check if user is allowed to view task info
                 proposal = result.info.get('proposal_ref', '')
                 messages = result.info.get('description', [])
-
             else:
-                # this path should never materialize
-                logger.error(
-                    'result.info attribute %s instead of dict', type(result.info)
+                # The result should have 'info' but potential race conditions
+                # mean it isn't there. Here we 'assume" the task has yet to start,
+                # so we return an UNKNOWN. A future call may have the 'info' property.
+                logger.warning(
+                    'AsyncResult info for %s is %s instead of dict',
+                    task_id_str,
+                    type(result.info),
                 )
-                return Response(
-                    {'error': f'Unexpected messages format: {result.info}'},
-                    status=status.HTTP_403_FORBIDDEN,
-                )
+                data = {
+                    'started': False,
+                    'finished': False,
+                    'status': task_status,
+                    'messages': messages,
+                }
+                return JsonResponse(data)
         else:
             error = {'error': 'Task messages not found. Try again later'}
             return Response(error, status=status.HTTP_404_NOT_FOUND)
@@ -2027,7 +2033,6 @@ class TaskStatusView(APIView):
 
         started = result.state != 'PENDING'
         finished = result.ready()
-        task_status = "UNKNOWN"
         if finished and messages:
             # The task is considered to have failed if the word 'FAILED'
             # is in the last line of the message (regardless of case)

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -2028,7 +2028,7 @@ class TaskStatusView(APIView):
                 request.user
             ):
                 return Response(
-                    {'error': 'You are not a member of the proposal f"proposal"'},
+                    {'error': f'You are not a member of the proposal {proposal}'},
                     status=status.HTTP_403_FORBIDDEN,
                 )
 

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -1987,9 +1987,10 @@ class TaskStatusView(APIView):
                 proposal = result.info.get('proposal_ref', '')
                 messages = result.info.get('description', [])
             else:
-                # The result should have 'info' but potential race conditions
-                # mean it isn't there. Here we 'assume" the task has yet to start,
-                # so we return an UNKNOWN. A future call may have the 'info' property.
+                # The result 'info' should be a 'dict' but suspected race conditions
+                # occasionally mean it's 'None'. Here we 'assume" the task has yet
+                # to be handled internally, so we log a warning and return an
+                # UNKNOWN status.
                 logger.warning(
                     'AsyncResult info for %s is %s instead of dict',
                     task_id_str,


### PR DESCRIPTION
- The error condition is now considered 'transient' and instead of issuing a `403` an `UNKNOWN` status response is returned.
- This also fixes the **You are not a member of the proposal** response message