### PR TITLE
Fixed LoggerAdapter (and task now last 6 characters) (2146)

### DIFF
--- a/viewer/logger_adapters.py
+++ b/viewer/logger_adapters.py
@@ -10,14 +10,18 @@ class TaskLoggerAdapter(logging.LoggerAdapter):
     provides at least a 'task' (a UUID string). It also supports 'target', 'tas', and
     'username' keys.
 
-    The generated string always contains '.T.<task ID>' that optionally also contains
+    The generated prefix string always contains the last 6 characters of the Task UUID
+    string printed as '.T.<task ID>'. The string also optionally contains
     't(<target>)', 'tas(<tas>)', and 'u(<username>)'. If the username exists but
     is blank, the username is replaced with '|anon|'.
     """
 
     def process(self, msg, kwargs):
         assert self.extra
-        rendered_extra: str = f"'.T.{self.extra['task']}"
+        if 'task' in self.extra and len(str(self.extra['task'])) > 6:
+            rendered_extra: str = f"'.T.{str(self.extra['task'])[-6:]}"
+        else:
+            rendered_extra = ".T.000000"
         if 'target' in self.extra:
             rendered_extra += f" t({self.extra['target']})"
         if 'tas' in self.extra:
@@ -27,4 +31,4 @@ class TaskLoggerAdapter(logging.LoggerAdapter):
                 rendered_extra += f" u({self.extra['username']})"
             else:
                 rendered_extra += " u(|anon|)"
-        return (rendered_extra, kwargs)
+        return '%s %s' % (rendered_extra, msg), kwargs


### PR DESCRIPTION
- Fix typo in TaskLoggerAdapter
- Only last 6 characters of task displayed
- Protected against no task ID