### PR TITLE
Expose shutil.rmtree() errors and reduced logging in other areas

### DIFF
--- a/api/security.py
+++ b/api/security.py
@@ -226,19 +226,19 @@ class ISPyBSafeStaticFiles:
         return queryset
 
     def get_response(self):
-        logger.info("+ get_response called with: %s", self.input_string)
+        logger.debug("+ get_response called with: %s", self.input_string)
         try:
             queryset = self.get_queryset()
             filter_dict = {self.field_name + "__endswith": self.input_string}
-            logger.info("filter_dict: %r", filter_dict)
+            logger.debug("filter_dict: %r", filter_dict)
             # instance = queryset.get(**filter_dict)
             instance = queryset.filter(**filter_dict)[0]
-            logger.info("instance: %r", instance)
+            logger.debug("instance: %r", instance)
 
             file_name = os.path.basename(str(getattr(instance, self.field_name)))
 
-            logger.info("instance: %r", instance)
-            logger.info("Path to pass to nginx: %s", self.prefix + file_name)
+            logger.debug("instance: %r", instance)
+            logger.debug("Path to pass to nginx: %s", self.prefix + file_name)
 
             if hasattr(self, 'file_format'):
                 if self.file_format == 'raw':
@@ -266,21 +266,21 @@ class ISPyBSafeStaticFiles:
 
 class ISPyBSafeStaticFiles2(ISPyBSafeStaticFiles):
     def get_response(self):
-        logger.info("+ get_response called with: %s", self.input_string)
+        logger.debug("+ get_response called with: %s", self.input_string)
         # it wasn't working because found two objects with test file name
         # so it doesn't help me here..
         try:
             # file_name = Path('/').joinpath(self.prefix).joinpath(self.input_string)
             # file_name = Path(self.prefix).joinpath(self.input_string)
             file_name = str(Path('/').joinpath(self.prefix).joinpath(self.input_string))
-            logger.info("Path to pass to nginx: %s", file_name)
+            logger.debug("Path to pass to nginx: %s", file_name)
             response = HttpResponse()
             response["Content-Type"] = self.content_type
             response["X-Accel-Redirect"] = file_name
             # response["Content-Disposition"] = "attachment;filename=" + file_name.name
             response["Content-Disposition"] = "attachment;filename=" + self.input_string
 
-            logger.info("- Response resolved: %r", response)
+            logger.debug("- Response resolved: %r", response)
             return response
         except Exception as exc:
             logger.error(exc, exc_info=True)

--- a/media_serve/views.py
+++ b/media_serve/views.py
@@ -13,7 +13,7 @@ def file_download(request, file_path):
     :param file_path: the file path we're getting from the static
     :return: the response (a redirect to nginx internal)
     """
-    logger.info("+ Received file_download file path: %s", file_path)
+    logger.debug("+ Received file_download file path: %s", file_path)
     ispy_b_static = ISPyBSafeStaticFiles2()
     # ispy_b_static = ISpyBSafeStaticFiles()
     ispy_b_static.model = SiteObservation
@@ -38,7 +38,7 @@ def tld_download(request, file_path):
     :param file_path: the file path we're getting from the static
     :return: the response (a redirect to nginx internal)
     """
-    logger.info("+ Received tld_download file path: %s", file_path)
+    logger.debug("+ Received tld_download file path: %s", file_path)
     ispy_b_static = ISPyBSafeStaticFiles2()
     # ispy_b_static = ISpyBSafeStaticFiles()
     ispy_b_static.model = SiteObservation
@@ -59,7 +59,7 @@ def cspdb_download(request, file_path):
     :param file_path: the file path we're getting from the static
     :return: the response (a redirect to nginx internal)
     """
-    logger.info("+ Received cspdb_download file path: %s", file_path)
+    logger.debug("+ Received cspdb_download file path: %s", file_path)
     ispy_b_static = ISPyBSafeStaticFiles2()
     ispy_b_static.model = SiteObservation
     ispy_b_static.request = request

--- a/viewer/download_structures.py
+++ b/viewer/download_structures.py
@@ -1434,40 +1434,43 @@ def erase_out_of_date_download_records():
     with the file-system the model should continue to reflect the current state
     of the world.
     """
-    logger.info('Erasing...')
-
     num_removed = 0
     out_of_date_dynamic_records = DownloadLinks.objects.filter(
         keep_zip_until__lt=datetime.now(timezone.utc)
     ).filter(static_link=False)
     for out_of_date_dynamic_record in out_of_date_dynamic_records:
         file_url = out_of_date_dynamic_record.file_url
-        logger.debug(
-            '+ Attempting to remove download link record (file_url=%s)...', file_url
+        logger.info(
+            'DownloadLinks record is too old (file_url=%s create_date=%s keep_zip_until=%s)...',
+            file_url,
+            out_of_date_dynamic_record.create_date,
+            out_of_date_dynamic_record.keep_zip_until,
         )
 
         dir_name = os.path.dirname(file_url)
         if os.path.isdir(dir_name):
-            logger.debug('Removing file_url directory (%s)...', dir_name)
-            shutil.rmtree(dir_name, ignore_errors=True)
-            logger.debug('Removed (%s)', dir_name)
+            logger.debug('Removing %s...', dir_name)
+            try:
+                shutil.rmtree(dir_name)
+                logger.debug('Removed %s', dir_name)
+            except Exception as ex:
+                logger.warning('Failed to remove %s (%s)', dir_name, ex)
 
-        # Does the file exist now?
+        # Does the file directory exist now?
         # Hopefully not - but cater for 'cosmic-ray-effect' and
-        # only delete the originating record if the file has been removed.
+        # only delete the originating record if the directory has been removed.
         if os.path.isdir(dir_name):
             logger.warning(
-                'Failed removal of file_url directory (%s), leaving DownloadLinks record',
+                'Failed to remove %s, leaving record alone',
                 dir_name,
             )
         else:
-            logger.info(
-                'Removing out-of-date DownloadLinks record (file_url=%s)...', file_url
-            )
             out_of_date_dynamic_record.delete()
             num_removed += 1
+            logger.debug('DownloadLinks record deleted (file_url=%s)...', file_url)
 
-    logger.info('Erased %d', num_removed)
+    if num_removed:
+        logger.info('Erased %d out of date DownloadLinks records', num_removed)
 
 
 # TODO: issue with single_sdf file


### PR DESCRIPTION
- Caught rmtree() failing to remove a download directory so logging in this area is improved
- INFO logging in security set to DEBUG
- INFO logging in media-serve/views  set to DEBUG