### PR TITLE
Target upload 'file' field is now 'required' (the default)

### DIFF
--- a/viewer/serializers.py
+++ b/viewer/serializers.py
@@ -989,7 +989,7 @@ class TargetExperimentReadSerializer(ValidateProjectMixin, serializers.ModelSeri
 
 class TargetExperimentWriteSerializer(serializers.ModelSerializer):
     target_access_string = serializers.CharField(label='Target Access String')
-    file = serializers.FileField(required=False)
+    file = serializers.FileField()
     sha256checksum = serializers.CharField(required=False)
 
     def validate(self, data):


### PR DESCRIPTION
- File, required, is now correctly set as required by the serialiser
  (by not saying required=False)