### PR TITLE
Use of task ID for new downloads, and file_url just contains filename

### DIFF
--- a/viewer/download_structures.py
+++ b/viewer/download_structures.py
@@ -12,7 +12,6 @@ import os
 import shutil
 import subprocess
 import time
-import uuid
 import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -1282,8 +1281,10 @@ def create_download(download_link_id: int, task, use_zip: bool = False):
         filename = f'{download_link.target.title}.zip'
     else:
         filename = f'{download_link.target.title}.tar.gz'
+    # The per-download directory uses the task_id (set above) so the path is
+    # reproducible from the model alone — see DownloadLinks.get_file_url().
     file_url = os.path.join(
-        settings.MEDIA_ROOT, 'downloads', str(uuid.uuid4()), filename
+        settings.MEDIA_ROOT, 'downloads', download_link.task_id, filename
     )
 
     with TemporaryDirectory() as tempdir:
@@ -1315,8 +1316,10 @@ def create_download(download_link_id: int, task, use_zip: bool = False):
     )
 
     # We now have a download file
-    # so record it and set the 'keep unitl' (expiry) time
-    download_link.file_url = file_url
+    # so record it and set the 'keep unitl' (expiry) time. file_url stores
+    # the basename only; the absolute path is reconstructed by
+    # DownloadLinks.get_file_url().
+    download_link.file_url = filename
     download_link.keep_zip_until = datetime.now(timezone.utc) + KEEP_UNTIL_DURATION
     download_link.save()
 
@@ -1387,8 +1390,13 @@ def hard_erase_out_of_date_download_records():
             num_pending += 1
             continue
 
-        file_url = dead_dynamic_record.file_url
-        dir_name = os.path.dirname(file_url)
+        full_path = dead_dynamic_record.get_file_url()
+        if full_path is None:
+            # Already cleared (no file_url / task_id); nothing to remove.
+            dead_dynamic_record.deleted = True
+            dead_dynamic_record.save()
+            continue
+        dir_name = os.path.dirname(full_path)
         logger.debug('Deleting %s...', dir_name)
         if os.path.isdir(dir_name):
             try:

--- a/viewer/migrations/0155_downloadlinks_file_url_basename.py
+++ b/viewer/migrations/0155_downloadlinks_file_url_basename.py
@@ -1,0 +1,50 @@
+"""Convert DownloadLinks.file_url from absolute path to basename.
+
+The absolute path is now reconstructed at access time via
+DownloadLinks.get_file_url() using MEDIA_ROOT, the "downloads" subdir and
+task_id. This migration:
+
+  1. Backfills existing rows: copies the per-download UUID directory from
+     the old absolute path into task_id and replaces
+     file_url with the original basename.
+  2. Drops the unique=True constraint, since two records for different tasks
+     can legitimately produce the same filename (e.g. "TARGET.zip").
+"""
+import os
+
+from django.db import migrations, models
+
+
+def _strip_path(apps, schema_editor):
+    DownloadLinks = apps.get_model('viewer', 'DownloadLinks')
+    for record in DownloadLinks.objects.exclude(file_url__isnull=True).exclude(
+        file_url__exact=''
+    ):
+        old_value = record.file_url
+        # Old format was "{MEDIA_ROOT}/downloads/{uuid}/{filename}".
+        # Replace old task_ids with the parent directory name (the original uuid) if present.
+        record.task_id = os.path.basename(os.path.dirname(old_value)) or record.task_id
+        record.file_url = os.path.basename(old_value)
+        record.save(update_fields=['file_url', 'task_id'])
+
+
+def _noop_reverse(apps, schema_editor):
+    # Reversing the data change isn't safe — we'd have to guess MEDIA_ROOT.
+    # Schema rollback is handled by the AlterField below; data stays as-is.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('viewer', '0154_project_alias_alter_project_title'),
+    ]
+
+    operations = [
+        migrations.RunPython(_strip_path, _noop_reverse),
+        migrations.AlterField(
+            model_name='downloadlinks',
+            name='file_url',
+            field=models.TextField(db_index=True, null=True),
+        ),
+    ]

--- a/viewer/models.py
+++ b/viewer/models.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import os
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -1536,8 +1537,11 @@ class DiscourseTopic(models.Model):
 class DownloadLinks(models.Model):
     """Searches made with the download_structures api."""
 
+    # Stores the basename of the download file (e.g. "TARGET.zip"). The
+    # absolute path is reconstructed via get_file_url() using MEDIA_ROOT,
+    # the "downloads" subdir and task_id. Not unique because two records
+    # for different tasks can produce the same filename.
     file_url = models.TextField(
-        unique=True,
         db_index=True,
         null=True,
     )
@@ -1606,6 +1610,19 @@ class DownloadLinks(models.Model):
             self.file_url,
             self.user,
             self.target,
+        )
+
+    def get_file_url(self):
+        """Reconstruct the absolute filesystem path of the download file.
+
+        Returns None when either file_url (the basename) or task_id (the
+        per-download directory name) is missing — i.e. the download has
+        not been built or has been hard-erased.
+        """
+        if not self.file_url or not self.task_id:
+            return None
+        return os.path.join(
+            settings.MEDIA_ROOT, 'downloads', self.task_id, self.file_url
         )
 
     class Meta:

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -1590,17 +1590,27 @@ class DownloadStructuresView(
         file_url = request.GET.get('file_url')
 
         if file_url:
-            if models.DownloadLinks.objects.filter(file_url=file_url).first():
+            # The DB now stores the basename only; the per-download directory
+            # is the task_id. Extract both from the client-supplied path so
+            # the lookup remains exact rather than substring-matching.
+            task_id = os.path.basename(os.path.dirname(file_url))
+            file_name = os.path.basename(file_url)
+            record = models.DownloadLinks.objects.filter(
+                task_id=task_id,
+                file_url=file_name,
+            ).first()
+            if record:
                 logger.info('Got DownloadLinks record for %s', file_url)
-                assert os.path.isfile(file_url)
+                full_path = record.get_file_url()
+                assert full_path is not None
+                assert os.path.isfile(full_path)
 
-                file_name = os.path.basename(file_url)
-                wrapper = FileWrapper(open(file_url, 'rb'))
+                wrapper = FileWrapper(open(full_path, 'rb'))
                 response = FileResponse(wrapper, content_type='application/zip')
                 response['Content-Disposition'] = (
                     'attachment; filename="%s"' % file_name
                 )
-                response['Content-Length'] = os.path.getsize(file_url)
+                response['Content-Length'] = os.path.getsize(full_path)
                 return response
             else:
                 content = {'message': 'file_url is not found'}
@@ -1669,16 +1679,18 @@ class DownloadStructuresView(
             file_url = serializer.validated_data['file_url']
             logger.info('Given file_url "%s"', file_url)
             existing_link = models.DownloadLinks.objects.filter(
-                file_url=file_url
+                task_id=os.path.basename(os.path.dirname(file_url)),
+                file_url=os.path.basename(file_url),
             ).first()
 
             if existing_link and existing_link.static_link:
                 # A record exists, the file _must_ exist.
-                file_url = existing_link.file_url
-                logger.info('Existing static link found for file_url "%s"', file_url)
-                assert os.path.isfile(file_url)
+                full_path = existing_link.get_file_url()
+                logger.info('Existing static link found for file_url "%s"', full_path)
+                assert full_path is not None
+                assert os.path.isfile(full_path)
                 return Response(
-                    {"file_url": file_url},
+                    {"file_url": full_path},
                     status=status.HTTP_200_OK,
                 )
 
@@ -1813,7 +1825,7 @@ class DownloadStructuresView(
 
         # Did we find an existing DownloadLink with exact same parameters?
         if existing_link:
-            return Response({"file_url": existing_link.file_url})
+            return Response({"file_url": existing_link.get_file_url()})
 
         # Do we have a suitable record for a compression task that's underway
         # (i.e. has a Task ID) and not expired?


### PR DESCRIPTION
- file_url is now just a filename
- task_id is now used as the download directory
- original file_url now obtained via get_file_url()
- includes migrations and back-propagation of existing DownloadLinks records

> Currently testing the change on my stack