### PR TITLE
Focussed cache clearing

### DIFF
--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -271,13 +271,6 @@ REDIS_CACHE_LOCATION = os.environ.get("REDIS_CACHE_LOCATION", "redis://redis:637
 CACHES = {
     "default": {
         "BACKEND": (
-            "django.core.cache.backends.locmem.LocMemCache"
-            if CACHE_ENABLED
-            else "django.core.cache.backends.dummy.DummyCache"
-        ),
-    },
-    "redis": {
-        "BACKEND": (
             "django.core.cache.backends.redis.RedisCache"
             if CACHE_ENABLED
             else "django.core.cache.backends.dummy.DummyCache"

--- a/launch-stack.sh
+++ b/launch-stack.sh
@@ -53,6 +53,8 @@ echo "Testing nginx config..."
 nginx -tq
 
 if [ "${HOSTNAME}" = "stack-0" ]; then
+    echo "Clearing the page cache"
+    python manage.py clear_cache
     echo "Launching service health check queries"
     python manage.py start_service_queries &
     echo "Launching download cleanup scheduler"

--- a/viewer/cache.py
+++ b/viewer/cache.py
@@ -1,0 +1,38 @@
+"""Targeted page-cache invalidation by view key_prefix.
+
+Each cached view in viewer/views.py passes a unique key_prefix to cache_page.
+clear_view_cache(*prefixes) drops the entries matching those prefixes — using
+Redis SCAN/DELETE when the active cache backend is Redis, or clearing the
+whole alias for backends without pattern delete.
+"""
+import logging
+
+from django.conf import settings
+from django.core.cache import caches
+from django.core.cache.backends.redis import RedisCache
+
+logger = logging.getLogger(__name__)
+
+
+def clear_view_cache(*prefixes: str) -> None:
+    """Invalidate cached pages whose key_prefix matches one of `prefixes`.
+
+    With Redis, scans and deletes only the affected keys. With other backends
+    (LocMemCache, DummyCache) there's no pattern delete, so the whole alias
+    is cleared instead — coarser but correct.
+    """
+    if not prefixes:
+        return
+    cache = caches[settings.CACHE_MIDDLEWARE_ALIAS]
+    if not isinstance(cache, RedisCache):
+        cache.clear()
+        return
+
+    # pylint: disable=protected-access
+    client = cache._cache.get_client(write=True)
+    for prefix in prefixes:
+        # cache_page stores per-user content under "...cache_page.{prefix}.{...}"
+        # and the Vary lookup under "...cache_header.{prefix}.{...}"; clear both.
+        for pattern in (f"*.cache_page.{prefix}.*", f"*.cache_header.{prefix}.*"):
+            for key in client.scan_iter(match=pattern, count=500):
+                client.delete(key)

--- a/viewer/cache.py
+++ b/viewer/cache.py
@@ -36,3 +36,12 @@ def clear_view_cache(*prefixes: str) -> None:
         for pattern in (f"*.cache_page.{prefix}.*", f"*.cache_header.{prefix}.*"):
             for key in client.scan_iter(match=pattern, count=500):
                 client.delete(key)
+
+
+def clear_all_view_caches() -> None:
+    """Drop every entry in the configured page-cache alias.
+
+    Coarser than clear_view_cache(...) — used by management commands where
+    the operator wants a full flush rather than per-view invalidation.
+    """
+    caches[settings.CACHE_MIDDLEWARE_ALIAS].clear()

--- a/viewer/management/commands/clear_cache.py
+++ b/viewer/management/commands/clear_cache.py
@@ -1,0 +1,24 @@
+"""Drop every entry in the configured page-cache alias.
+
+Useful after schema migrations, manual DB edits, or any out-of-band change
+that wouldn't have triggered the per-view invalidation hooks in views.py
+and tasks.py.
+"""
+from django.conf import settings
+from django.core.cache import caches
+from django.core.management.base import BaseCommand
+
+from viewer.cache import clear_all_view_caches
+
+
+class Command(BaseCommand):
+    help = "Clear the entire page cache (configured CACHE_MIDDLEWARE_ALIAS)."
+
+    def handle(self, *args, **kwargs):
+        del args, kwargs
+        alias = settings.CACHE_MIDDLEWARE_ALIAS
+        backend = type(caches[alias]).__name__
+        clear_all_view_caches()
+        self.stdout.write(
+            self.style.SUCCESS(f"Cleared cache alias '{alias}' ({backend}).")
+        )

--- a/viewer/management/commands/curated_tags.py
+++ b/viewer/management/commands/curated_tags.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand
 
+from viewer.cache import clear_all_view_caches
 from viewer.utils import dump_curated_tags, restore_curated_tags
 
 
@@ -25,3 +26,6 @@ class Command(BaseCommand):
             dump_curated_tags(filename=kwargs["dump"])
         if kwargs["load"]:
             restore_curated_tags(filename=kwargs["load"])
+            # Tag rows have changed; cached tag/observation/pose responses
+            # may be stale.
+            clear_all_view_caches()

--- a/viewer/management/commands/load_target.py
+++ b/viewer/management/commands/load_target.py
@@ -7,7 +7,6 @@ from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 from django.db import IntegrityError
 
-from viewer.cache import clear_all_view_caches
 from viewer.target_loader import load_target
 
 
@@ -67,9 +66,6 @@ class Command(BaseCommand):
                 proposal_ref=kwargs['proposal_ref'],
                 user_id=user_id,
             )
-            # SiteObservation, Pose and SiteObservationTag rows have just
-            # been written; flush cached responses that read them.
-            clear_all_view_caches()
             # self.stdout.write(self.style.SUCCESS('Data imported'))
         except KeyError as err:
             self.stdout.write(self.style.ERROR(err.args[0]))

--- a/viewer/management/commands/load_target.py
+++ b/viewer/management/commands/load_target.py
@@ -7,6 +7,7 @@ from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 from django.db import IntegrityError
 
+from viewer.cache import clear_all_view_caches
 from viewer.target_loader import load_target
 
 
@@ -66,6 +67,9 @@ class Command(BaseCommand):
                 proposal_ref=kwargs['proposal_ref'],
                 user_id=user_id,
             )
+            # SiteObservation, Pose and SiteObservationTag rows have just
+            # been written; flush cached responses that read them.
+            clear_all_view_caches()
             # self.stdout.write(self.style.SUCCESS('Data imported'))
         except KeyError as err:
             self.stdout.write(self.style.ERROR(err.args[0]))

--- a/viewer/management/commands/move_target_project.py
+++ b/viewer/management/commands/move_target_project.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand
 
+from viewer.cache import clear_all_view_caches
 from viewer.utils import change_target_project
 
 
@@ -37,3 +38,7 @@ class Command(BaseCommand):
             )
         except ValueError as exc:
             self.stdout.write(self.style.ERROR(exc.args[0]))
+            return
+        # Reproject changes which users see this target's data via
+        # ISPyBSafeQuerySet's project filter; flush cached responses.
+        clear_all_view_caches()

--- a/viewer/management/commands/tags_from_sites.py
+++ b/viewer/management/commands/tags_from_sites.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 # from scoring.models import MolGroup
 from scoring.models import SiteObservationGroup
+from viewer.cache import clear_all_view_caches
 from viewer.models import SiteObservation, SiteObservationTag, TagCategory, Target
 
 
@@ -137,6 +138,10 @@ class Command(BaseCommand):
 
         if tags_created == expected_sites:
             self.stdout.write('Looking good - tags_created = expected sites')
+
+        if update and tags_created:
+            # New SiteObservationTag rows; flush cached responses.
+            clear_all_view_caches()
 
         time_end = timezone.now().strftime('%X')
         self.stdout.write("End %s" % time_end)

--- a/viewer/target_loader.py
+++ b/viewer/target_loader.py
@@ -36,6 +36,7 @@ from rdkit import Chem
 from api.utils import deployment_mode_is_production
 from fragalysis.settings import TARGET_LOADER_MEDIA_DIRECTORY
 from scoring.models import SiteObservationGroup
+from viewer.cache import clear_view_cache
 from viewer.models import (
     AtomCoordinates,
     CanonSite,
@@ -3772,6 +3773,23 @@ def check_decompress_progress(process, archive_path, update, frequency=1.0):
 
 
 def load_target(
+    data_bundle,
+    proposal_ref: str,
+    user_id=None,
+    task=None,
+):
+    # Any run of load_target may have written (or partially written)
+    # SiteObservation, Pose and SiteObservationTag rows before raising or
+    # returning early — drop the cached views that read those models in a
+    # `finally` so callers don't have to remember, and so invalidation is
+    # guaranteed even on failure paths.
+    try:
+        _load_target(data_bundle, proposal_ref, user_id=user_id, task=task)
+    finally:
+        clear_view_cache("tag", "pose", "site-observation")
+
+
+def _load_target(
     data_bundle,
     proposal_ref: str,
     user_id=None,

--- a/viewer/target_loader.py
+++ b/viewer/target_loader.py
@@ -3778,23 +3778,6 @@ def load_target(
     user_id=None,
     task=None,
 ):
-    # Any run of load_target may have written (or partially written)
-    # SiteObservation, Pose and SiteObservationTag rows before raising or
-    # returning early — drop the cached views that read those models in a
-    # `finally` so callers don't have to remember, and so invalidation is
-    # guaranteed even on failure paths.
-    try:
-        _load_target(data_bundle, proposal_ref, user_id=user_id, task=task)
-    finally:
-        clear_view_cache("tag", "pose", "site-observation")
-
-
-def _load_target(
-    data_bundle,
-    proposal_ref: str,
-    user_id=None,
-    task=None,
-):
     with TemporaryDirectory(dir=settings.MEDIA_ROOT) as tempdir:
         target_loader = TargetLoader(
             data_bundle, proposal_ref, tempdir, user_id=user_id, task=task
@@ -3855,6 +3838,11 @@ def _load_target(
                     raise IntegrityError(
                         f"Uploading {target_loader.data_bundle} failed"
                     )
+                # process_bundle wrote SiteObservation, Pose and
+                # SiteObservationTag rows — drop the cached views that read
+                # those models. Inside the atomic block so we only invalidate
+                # when the writes are actually going to commit.
+                clear_view_cache("tag", "pose", "site-observation")
         except Exception as exc:
             # Handle _any_ underlying problem.
             # These are errors processing the data, which we handle gracefully.

--- a/viewer/tasks.py
+++ b/viewer/tasks.py
@@ -27,6 +27,7 @@ from fragalysis.celery import app as celery_app
 from viewer.models import Compound, DesignSet
 from viewer.target_loader import load_target
 
+from .cache import clear_view_cache
 from .cset_upload import MolOps, PdbOps, blank_mol_vals
 from .download_structures import create_download
 from .models import ComputedSet, JobFileTransfer, JobRequest, SiteObservation
@@ -133,6 +134,10 @@ def process_compound_set(validate_output):
         computed_set_id=computed_set_id,
     )
     compound_set, process_messages = save_mols.task()
+
+    # ComputedMolecule rows have just been written; drop both
+    # ComputedMoleculesView and ComputedMolAndScoreView caches.
+    clear_view_cache("computed-molecules")
 
     logger.info('process_compound_set() EXIT (CompoundSet.id="%s")', compound_set.id)
     return 'process', compound_set.id, process_messages
@@ -533,6 +538,9 @@ def task_load_target(self, data_bundle=None, proposal_ref=None, user_id=None):
         user_id=user_id,
         task=self,
     )
+    # Target ingestion creates SiteObservation, Pose and SiteObservationTag
+    # rows — drop the cached views that read those models.
+    clear_view_cache("tag", "pose", "site-observation")
     logger.info(
         'TASK %s load_target completed, target_zip=%s', self.request.id, data_bundle
     )

--- a/viewer/tasks.py
+++ b/viewer/tasks.py
@@ -538,9 +538,6 @@ def task_load_target(self, data_bundle=None, proposal_ref=None, user_id=None):
         user_id=user_id,
         task=self,
     )
-    # Target ingestion creates SiteObservation, Pose and SiteObservationTag
-    # rows — drop the cached views that read those models.
-    clear_view_cache("tag", "pose", "site-observation")
     logger.info(
         'TASK %s load_target completed, target_zip=%s', self.request.id, data_bundle
     )

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -66,6 +66,7 @@ from viewer.utils import (
 )
 
 from .assay_data import AssayData, convert
+from .cache import clear_view_cache
 from .discourse import (
     check_discourse_user,
     create_discourse_post,
@@ -1231,11 +1232,14 @@ class ComputedMoleculesView(ISPyBSafeQuerySet):
     filterset_fields = ('computed_set',)
 
     # Vary keys the cache on Authorization/Cookie so per-user
-    # proposal filtering from ISPyBSafeQuerySet is preserved.
+    # proposal filtering from ISPyBSafeQuerySet is preserved. The key_prefix
+    # is shared with ComputedMolAndScoreView so a single
+    # clear_view_cache("computed-molecules") drops both.
     @method_decorator(
         cache_page(
             settings.CACHE_MIDDLEWARE_SECONDS,
             cache=settings.CACHE_MIDDLEWARE_ALIAS,
+            key_prefix="computed-molecules",
         )
     )
     @method_decorator(vary_on_headers('Authorization', 'Cookie'))
@@ -1246,6 +1250,7 @@ class ComputedMoleculesView(ISPyBSafeQuerySet):
         cache_page(
             settings.CACHE_MIDDLEWARE_SECONDS,
             cache=settings.CACHE_MIDDLEWARE_ALIAS,
+            key_prefix="computed-molecules",
         )
     )
     @method_decorator(vary_on_headers('Authorization', 'Cookie'))
@@ -1292,12 +1297,13 @@ class ComputedMolAndScoreView(ISPyBSafeQuerySet):
     filter_permissions = "compound__project_id"
     filterset_fields = ('computed_set',)
 
-    # Vary keys the cache on Authorization/Cookie so per-user
-    # proposal filtering from ISPyBSafeQuerySet is preserved.
+    # Shares the "computed-molecules" key_prefix with ComputedMoleculesView
+    # since both depend on the same underlying ComputedMolecule model.
     @method_decorator(
         cache_page(
             settings.CACHE_MIDDLEWARE_SECONDS,
             cache=settings.CACHE_MIDDLEWARE_ALIAS,
+            key_prefix="computed-molecules",
         )
     )
     @method_decorator(vary_on_headers('Authorization', 'Cookie'))
@@ -1308,6 +1314,7 @@ class ComputedMolAndScoreView(ISPyBSafeQuerySet):
         cache_page(
             settings.CACHE_MIDDLEWARE_SECONDS,
             cache=settings.CACHE_MIDDLEWARE_ALIAS,
+            key_prefix="computed-molecules",
         )
     )
     @method_decorator(vary_on_headers('Authorization', 'Cookie'))
@@ -1496,12 +1503,11 @@ class SiteObservationTagView(
         'mol_group',
     )
 
-    # Vary keys the cache on Authorization/Cookie so per-user
-    # proposal filtering from ISPyBSafeQuerySet is preserved.
     @method_decorator(
         cache_page(
             settings.CACHE_MIDDLEWARE_SECONDS,
             cache=settings.CACHE_MIDDLEWARE_ALIAS,
+            key_prefix="tag",
         )
     )
     @method_decorator(vary_on_headers('Authorization', 'Cookie'))
@@ -1512,11 +1518,24 @@ class SiteObservationTagView(
         cache_page(
             settings.CACHE_MIDDLEWARE_SECONDS,
             cache=settings.CACHE_MIDDLEWARE_ALIAS,
+            key_prefix="tag",
         )
     )
     @method_decorator(vary_on_headers('Authorization', 'Cookie'))
     def retrieve(self, request, *args, **kwargs):
         return super().retrieve(request, *args, **kwargs)
+
+    def perform_create(self, serializer):
+        super().perform_create(serializer)
+        clear_view_cache("tag")
+
+    def perform_update(self, serializer):
+        super().perform_update(serializer)
+        clear_view_cache("tag")
+
+    def perform_destroy(self, instance):
+        super().perform_destroy(instance)
+        clear_view_cache("tag")
 
 
 class PoseView(
@@ -1532,12 +1551,11 @@ class PoseView(
     serializer_class = serializers.PoseSerializer
     filterset_class = filters.PoseFilter
 
-    # Vary keys the cache on Authorization/Cookie so per-user
-    # proposal filtering from ISPyBSafeQuerySet is preserved.
     @method_decorator(
         cache_page(
             settings.CACHE_MIDDLEWARE_SECONDS,
             cache=settings.CACHE_MIDDLEWARE_ALIAS,
+            key_prefix="pose",
         )
     )
     @method_decorator(vary_on_headers('Authorization', 'Cookie'))
@@ -1548,11 +1566,24 @@ class PoseView(
         cache_page(
             settings.CACHE_MIDDLEWARE_SECONDS,
             cache=settings.CACHE_MIDDLEWARE_ALIAS,
+            key_prefix="pose",
         )
     )
     @method_decorator(vary_on_headers('Authorization', 'Cookie'))
     def retrieve(self, request, *args, **kwargs):
         return super().retrieve(request, *args, **kwargs)
+
+    def perform_create(self, serializer):
+        super().perform_create(serializer)
+        clear_view_cache("pose")
+
+    def perform_update(self, serializer):
+        super().perform_update(serializer)
+        clear_view_cache("pose")
+
+    def perform_destroy(self, instance):
+        super().perform_destroy(instance)
+        clear_view_cache("pose")
 
 
 class SessionProjectTagView(
@@ -2335,12 +2366,11 @@ class SiteObservationView(ISPyBSafeQuerySet):
     filterset_class = filters.SiteObservationFilter
     filter_permissions = "experiment__experiment_upload__project"
 
-    # Vary keys the cache on Authorization/Cookie so per-user
-    # proposal filtering from ISPyBSafeQuerySet is preserved.
     @method_decorator(
         cache_page(
             settings.CACHE_MIDDLEWARE_SECONDS,
             cache=settings.CACHE_MIDDLEWARE_ALIAS,
+            key_prefix="site-observation",
         )
     )
     @method_decorator(vary_on_headers('Authorization', 'Cookie'))
@@ -2351,6 +2381,7 @@ class SiteObservationView(ISPyBSafeQuerySet):
         cache_page(
             settings.CACHE_MIDDLEWARE_SECONDS,
             cache=settings.CACHE_MIDDLEWARE_ALIAS,
+            key_prefix="site-observation",
         )
     )
     @method_decorator(vary_on_headers('Authorization', 'Cookie'))
@@ -3209,8 +3240,10 @@ class UploadMetadataView(ISPyBSafeQuerySet):
         errors = load_tags_from_file(filename=filename, target=target, user=user)
         if errors:
             return Response({"errors": errors}, status=status.HTTP_400_BAD_REQUEST)
-        else:
-            return Response({'success': True}, status=status.HTTP_200_OK)
+        # load_tags_from_file mutates SiteObservationTag, SiteObservation,
+        # and Pose; drop the corresponding cached responses.
+        clear_view_cache("tag", "site-observation", "pose")
+        return Response({'success': True}, status=status.HTTP_200_OK)
 
 
 class DownloadComputedSetView(ISPyBSafeQuerySet):


### PR DESCRIPTION
- Builds upon the existing cache implementation
- Cache is disabled by default (set `CACHE_ENABLED` to `"yes"` to enable)
- Default cache engine is redis
- Implementation is now redis-specific
- Cache is now selectively cleared
- Management commands now clear the cache
- Adds a new clear_cache management command 
- When stack-0 starts the entire cache is cleared