### PR TITLE
M2ms 2219 conflict auto patch

### DIFF
--- a/fragalysis/auth.py
+++ b/fragalysis/auth.py
@@ -3,6 +3,7 @@
 import logging
 
 from django.conf import settings
+from django.core.exceptions import PermissionDenied
 from django.db import IntegrityError, transaction
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 
@@ -13,6 +14,10 @@ logger = logging.getLogger(__name__)
 # account frees the username so the user does not have to log in again.
 # See m2ms-2116.
 _CONFLICT_PREFIX = "m2ms-2116-"
+
+# Only the username-collision IntegrityError carries this (Postgres) text.
+# Any other IntegrityError is not something we know how to recover from.
+_DUPLICATE_KEY_MESSAGE = "duplicate key value violates unique constraint"
 
 
 class KeycloakOIDCAuthenticationBackend(OIDCAuthenticationBackend):
@@ -83,15 +88,38 @@ class KeycloakOIDCAuthenticationBackend(OIDCAuthenticationBackend):
             with transaction.atomic():
                 user.save()
             return user
-        except IntegrityError:
+        except IntegrityError as exc:
+            if _DUPLICATE_KEY_MESSAGE not in str(exc):
+                # A different IntegrityError (not the username collision):
+                # fail the login cleanly with a 403 rather than a 500.
+                logger.error(
+                    "Unrecoverable IntegrityError saving id=%s username=%s: %s",
+                    user.id,
+                    username,
+                    exc,
+                )
+                raise PermissionDenied(
+                    "Could not complete login (database integrity error)."
+                ) from exc
+
             conflicting = list(
                 self.UserModel.objects.filter(username__iexact=username).exclude(
                     pk=user.pk
                 )
             )
             if not conflicting:
-                # Not the username collision we know how to resolve.
-                raise
+                # The username collision text was present but no other row
+                # holds it: we cannot recover, so 403 rather than 500.
+                logger.error(
+                    "Username collision for id=%s username=%s but no"
+                    " conflicting row found: %s",
+                    user.id,
+                    username,
+                    exc,
+                )
+                raise PermissionDenied(
+                    "Could not complete login (username conflict)."
+                ) from exc
 
             for other in conflicting:
                 new_username = f"{_CONFLICT_PREFIX}{other.username}"

--- a/fragalysis/auth.py
+++ b/fragalysis/auth.py
@@ -3,9 +3,16 @@
 import logging
 
 from django.conf import settings
+from django.db import IntegrityError, transaction
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 
 logger = logging.getLogger(__name__)
+
+# Prefix applied to a pre-existing account whose username collides with the
+# one an incoming (email-matched) login is claiming. Renaming the stale
+# account frees the username so the user does not have to log in again.
+# See m2ms-2116.
+_CONFLICT_PREFIX = "m2ms-2116-"
 
 
 class KeycloakOIDCAuthenticationBackend(OIDCAuthenticationBackend):
@@ -62,6 +69,58 @@ class KeycloakOIDCAuthenticationBackend(OIDCAuthenticationBackend):
 
         return users
 
+    def _save_resolving_username_conflict(self, user, username):
+        """Save 'user', recovering from the auth_user_username_key collision.
+
+        'user' has been matched by email but is being assigned a username
+        that another (stale) row already owns, so user.save() raises
+        IntegrityError. We rename the stale row (see _CONFLICT_PREFIX) to
+        free the username and retry, so the user does not have to log in
+        again. The first save runs in a savepoint so the connection stays
+        usable after the rollback.
+        """
+        try:
+            with transaction.atomic():
+                user.save()
+            return user
+        except IntegrityError:
+            conflicting = list(
+                self.UserModel.objects.filter(username__iexact=username).exclude(
+                    pk=user.pk
+                )
+            )
+            if not conflicting:
+                # Not the username collision we know how to resolve.
+                raise
+
+            for other in conflicting:
+                new_username = f"{_CONFLICT_PREFIX}{other.username}"
+                # A repeat collision (prefixed name already taken) would
+                # just violate the constraint again on retry, so fall
+                # back to a pk-qualified name that is guaranteed unique.
+                if (
+                    self.UserModel.objects.filter(username__iexact=new_username)
+                    .exclude(pk=other.pk)
+                    .exists()
+                ):
+                    new_username = f"{_CONFLICT_PREFIX}{other.pk}-{other.username}"
+                new_username = new_username[:150]
+                logger.warning(
+                    "Freeing username '%s': renaming conflicting"
+                    " id=%s username=%s -> %s",
+                    username,
+                    other.pk,
+                    other.username,
+                    new_username,
+                )
+                other.username = new_username
+                with transaction.atomic():
+                    other.save()
+
+            with transaction.atomic():
+                user.save()
+            return user
+
     def update_user(self, user, claims):
         """Update a user from a claim.
         We need the expected username field.
@@ -98,5 +157,4 @@ class KeycloakOIDCAuthenticationBackend(OIDCAuthenticationBackend):
         user.first_name = new_given_name
         user.last_name = new_last_name
 
-        user.save()
-        return user
+        return self._save_resolving_username_conflict(user, username)


### PR DESCRIPTION
  - `_save_resolving_username_conflict(user, username)` helper:
    - Saves inside a transaction.atomic() savepoint so the Postgres connection survives the IntegrityError rollback
  (without this, every subsequent query in the request would fail with "current transaction is aborted").
    - On IntegrityError, finds the other row(s) holding that username (username__iexact, excluding the current row).
    - If none found, the violation isn't the collision we handle → re-raise (don't mask unrelated errors).
    - Renames the stale row to m2ms-2116-<username>, saves it, then retries the original save and returns.
  - update_user now ends with return `self._save_resolving_username_conflict(user, username)` instead of `user.save()`.

  The user no longer has to re-login — the rename and retry happen within the same authentication call.
