### PR TITLE
docs: Add ARCHITECTURE.md, CLAUDE.md, and Claude Code project config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,7 @@
       "Bash(git commit -m ' *)",
       "Bash(git config *)",
       "Bash(gh api *)",
+      "Bash(gh pr *)",
       "Bash(poetry run *)",
       "Skill(build-stack)"
     ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(docker buildx *)",
+      "Bash(git branch *)",
+      "Bash(git config *)",
+      "Bash(gh api *)",
+      "Bash(poetry run *)",
+      "Skill(build-stack)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,9 @@
   "permissions": {
     "allow": [
       "Bash(docker buildx *)",
+      "Bash(git add *)",
       "Bash(git branch *)",
+      "Bash(git commit -m ' *)",
       "Bash(git config *)",
       "Bash(gh api *)",
       "Bash(poetry run *)",

--- a/.claude/skills/build-stack/SKILL.md
+++ b/.claude/skills/build-stack/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: build-stack
+description: Build a developer stack, which consists of backend and stack container images
+---
+
+To build a developer "stack" from the fragalysis-backend repository we build the
+fragalysis-backend container image first, and then switch to the fragalysis-stack
+project where we build and push the final application image. We don't build the
+front-end and instead rely on the frontend that is picked up in the stack Dockerfile
+(e.g. xchem/fragalysis-frontend:latest).
+
+Environment variables are used to control the build: -
+
+- BE_NAMESPACE is always "xchem"
+- BE_IMAGE_TAG is set to the current fragalysis-backend branch name (e.g. "m2ms-1234", the GITHUB_REF_SLUG)
+- STACK_NAMESPACE is the developer's GitHub username (e.g. "alanbchristie")
+- STACK_IMAGE_TAG is the same as BE_IMAGE_TAG
+
+>   If the developer is on staging or production there's no need to build anything,
+    as an official image will exist in `xchem/fragalysis-stack` DockerHub registry
+    (typically `xchem/fragalysis-stack:latest`)
+
+>   If there are no local modifications a built might not be necessary,
+    as the CI process (`build-dev.yaml`) ensures that a container image is built for
+    the current branch. If you're on branch `m2ms-1234` for example you might find
+    the image `xchem/fragalysis-backend:m2ms-1234` already exists.
+
+To build the fragalysis-backend AMD image: -
+
+```
+docker buildx build . --platform linux/amd64 \
+  -t ${BE_NAMESPACE}/fragalysis-backend:${BE_IMAGE_TAG}
+```
+
+Once the build has been successful we then move to the fragalysis-stack's project
+directory.
+
+>   If it is not present you can clone it from https://github.com/xchem/fragalysis-stack
+    and use the `master` branch: -
+
+```
+cd ../fragalysis-stack
+```
+
+Then we can build and push the fragalysis-stack image: -
+
+```
+docker buildx build . --platform linux/amd64 \
+  -t ${STACK_NAMESPACE}/fragalysis-stack:${STACK_IMAGE_TAG} \
+  --build-arg BE_NAMESPACE=${BE_NAMESPACE} --build-arg BE_IMAGE_TAG=${BE_IMAGE_TAG} \
+  --build-arg FE_NAMESPACE=${FE_NAMESPACE} --build-arg FE_IMAGE_TAG=${FE_IMAGE_TAG} \
+  --push
+```

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,10 @@ ENV/
 *~
 \#*#
 \#*
+
+# --- Claude Code session state / local plans ---
+.claude/*
+# ...but track the team-shared project settings and skills
+!.claude/settings.json
+!.claude/skills/
+!.claude/commands/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,166 @@
+# Architecture
+
+This document describes the *big-picture* design of the fragalysis-backend — the
+parts that span multiple files and are not obvious from any single module. For
+setup/commands see `README.md`; for working conventions see `CLAUDE.md`. Historical
+design rationale for individual features lives as PDFs/PlantUML in `design_docs/`.
+
+## The stack and where this fits
+
+The backend is one component of the deployed **Fragalysis stack**. At runtime it
+talks to four external services:
+
+- **PostgreSQL** — the primary relational store (with `pgvector` for embeddings).
+- **Neo4j** — a graph database, used for fragment-network queries (`network/`).
+- **Redis** — Celery broker/result backend and Django cache.
+- **Squonk2** (Data Manager + Account Server) — an external compute platform that
+  runs computational jobs; reached over HTTP via the `squonk2` Python client.
+
+The process model inside the container (`launch-stack.sh`): migrations →
+load fixtures → `collectstatic` → create superuser → **gunicorn** (the Django app)
+behind **nginx**. On the lead pod (`stack-0`) it also starts the service health-check
+scheduler and the download-cleanup scheduler. Celery **workers** and **beat** run as
+separate processes (`launch-worker.sh`, `launch-beat.sh`).
+
+## Django project layout
+
+`fragalysis/` is the Django *project* (settings, root URL conf, celery app, OIDC
+auth). The functionality is split across several *apps* (`INSTALLED_APPS` in
+`fragalysis/settings.py`), but the centre of gravity is overwhelmingly the **`viewer`**
+app — `viewer/views.py`, `viewer/models.py`, `viewer/serializers.py` and
+`viewer/target_loader.py` are each thousands of lines and contain most of the domain
+logic. The other apps (`scoring`, `hotspots`, `hypothesis`, `network`, `media_serve`,
+`service_status`) are comparatively small and focused.
+
+URL routing starts in `fragalysis/urls.py`, which includes each app's `urls.py`. Most
+data endpoints are DRF `ViewSet`s registered under `/api/`.
+
+## Domain model
+
+The data model (`viewer/models.py`) represents crystallographic fragment-screening
+data. The core hierarchy, roughly top-down:
+
+```
+Project (a.k.a. proposal/visit — the unit of ACCESS CONTROL)
+└── Target (a protein target)
+    ├── ExperimentUpload (one ingestion of data; created by the target loader)
+    │   └── Experiment (a crystal dataset; links Compounds + an Xtalform)
+    │       └── SiteObservation  ← the central "thing a user looks at":
+    │              a single observed ligand binding event
+    ├── Xtalform / XtalformSite / QuatAssembly  (crystal-form description)
+    ├── CanonSite / CanonSiteConf  (canonical binding sites + conformations)
+    └── Pose  (groups SiteObservations of one Compound at one CanonSite)
+
+Compound  — a unique 2D molecule (shared across targets)
+```
+
+Key relationships to know before touching models:
+
+- **`SiteObservation`** is the hub. It points to its `Experiment`, `Compound`
+  (`cmpd`), `XtalformSite`, `CanonSiteConf`, and `Pose`. Most user-facing data and
+  files hang off it.
+- **`CanonSite` ↔ `CanonSiteConf` ↔ `SiteObservation`** form a mutually-referential
+  cluster (a canon site has a reference conf; a conf has a reference observation).
+  This is why loading happens in carefully ordered passes (see below).
+- **`Versionable`** is an abstract base (`CanonSite`, `CanonSiteConf`,
+  `XtalformSite`, `SiteObservation` inherit it) supporting versioned/upgraded records.
+- Custom **managers** live in `viewer/managers.py` (one per major model) and encode
+  query logic — prefer extending these over ad-hoc querysets.
+- `django-simple-history` (`HistoricalRecords`) tracks changes on several models.
+
+**Computed sets** are a parallel, user-contributed branch: a `ComputedSet` of
+`ComputedMolecule`s (3D poses produced computationally) attached to a `Target`, each
+referencing a `Compound` and its inspiration `SiteObservation`s, with scores in
+`ScoreDescription`/`NumericalScoreValues`/`TextScoreValues`.
+
+**Sessions/snapshots** (`SessionProject`, `Snapshot`, `SessionActions`) persist a
+user's view state of a target page. **Tags** (`Tag` subclasses in `viewer/tags.py`)
+group observations and sessions.
+
+## Access control (read this before adding any data-exposing view)
+
+Authorisation is **proposal-based**, not row-level Django permissions. Every piece of
+target data ultimately belongs to a `Project` (a "proposal"/"visit"), and a user may
+only see data for proposals they are a member of, plus any proposal marked
+`open_to_public` or listed in `PUBLIC_TAS`.
+
+The mechanism is `api.security.ISPyBSafeQuerySet` (a DRF `ReadOnlyModelViewSet`
+subclass):
+
+- A view sets `filter_permissions` to the ORM path from its model to the owning
+  `Project` (e.g. `"target__project"`). `get_queryset()` builds a `Q` filter limiting
+  results to the user's proposals OR public proposals.
+- Membership comes from one of two sources, chosen by `settings.TA_AUTH_SERVICE`:
+  the external **Target-Access (TA) auth connector** (`api/ta_auth_connector.py`) when
+  configured, otherwise the local Django `Project.user` relation.
+- `restrict_public_to_membership` distinguishes *viewing* public data (everyone) from
+  *modifying/uploading* to a public proposal (explicit members only). Use the
+  `user_is_member_of_*` helpers for write paths.
+- Because `ISPyBSafeQuerySet` is read-only, views needing write methods add DRF
+  mixins explicitly.
+
+When adding an endpoint that returns target-scoped data, subclass `ISPyBSafeQuerySet`
+and set `filter_permissions` — do not write a plain `ModelViewSet`, or you will leak
+data across proposals.
+
+Authentication itself is **OIDC via Keycloak** (`mozilla_django_oidc`), configured in
+`settings.py` and `fragalysis/auth.py`.
+
+## Asynchronous work (Celery)
+
+Long-running operations are Celery tasks (`viewer/tasks.py`, broker = Redis). The
+major ones:
+
+- **`load_target`** — ingest a new target data package (delegates to
+  `viewer/target_loader.py`).
+- **`create_download`** — build a downloadable structures archive
+  (`viewer/download_structures.py`); cleaned up later by a scheduler.
+- **Computed-set upload** validation/processing (`viewer/cset_upload.py`).
+- **Squonk2 job** file transfer / upload / request handling
+  (`viewer/squonk_job_*.py`).
+
+Locally, tasks run **eagerly** (synchronously) unless the celery compose file is
+used — see `CLAUDE.md`. The pattern in views is: kick off a task, return a task id,
+and let the client poll a status endpoint.
+
+## The target-loading pipeline
+
+`viewer/target_loader.py` (~4k lines) is the most complex subsystem. It takes an
+uploaded archive describing a target (YAML metadata + structure files + an SDF/SQLite
+of observations), and populates the model hierarchy above inside a transaction. Two
+things to understand:
+
+1. **Ordered, multi-pass creation.** Because of the mutually-referential
+   CanonSite/Conf/SiteObservation relationships, records are created in dependency
+   order and back-references are filled in later passes.
+2. **Versioned re-uploads.** Re-uploading a target produces a new `ExperimentUpload`
+   and upgrades `Versionable` records rather than blindly duplicating.
+
+After a successful load it clears the view cache (`viewer/cache.py`) and derives tags.
+
+## Squonk2 integration
+
+External computational jobs run on the Squonk2 platform. `viewer/squonk2_agent.py`
+(`Squonk2Agent`, a process-wide singleton) wraps the Squonk2 client and maps
+Fragalysis `Project`s to Squonk2 `Org`/`Unit`/`Product`/`Project` records
+(`Squonk2Org`/`Squonk2Unit`/`Squonk2Project` models). The `squonk_job_*.py` modules
+orchestrate transferring input files to Squonk2, requesting a job (`JobRequest`),
+and handling success callbacks that ingest results back as a `ComputedSet`.
+
+## Caching, logging, configuration
+
+- **Cache:** per-view caching keyed appropriately; toggled by `CACHE_ENABLED` and
+  cleared via `viewer/cache.py` / the `clear_cache` management command.
+- **Logging:** configured in `settings.py` (console + rotating file at
+  `/code/logs/backend.log`); custom adapters in `viewer/logger_adapters.py`.
+- **Configuration** is environment-variable driven through `settings.py`; the file's
+  header comment is the authoritative style guide. `DEPLOYMENT_MODE` and `INFECTIONS`
+  (`api/infections.py`) alter behaviour for production-hardening and error-path
+  testing respectively.
+
+## Management commands
+
+Operational/maintenance tasks live in `viewer/management/commands/` (documented in
+that directory's `README.md`) and `service_status/` — e.g. `load_target`,
+`clear_cache`, `start_download_cleanup`, `start_service_queries`, and various
+one-off data-correction commands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+## The project
+
+The Django + Django REST Framework backend for the **Fragalysis** stack — a web
+application for visualising and analysing X-ray crystallographic fragment-screening
+data. This repo is one of several that make up the deployed "stack" (see README's
+*Background* section); it owns the database models, the REST API, data loaders, and
+the Celery tasks. It is deployed as a container image to Kubernetes.
+
+For the big-picture design (domain model, access control, async tasks, the
+target-loading pipeline, Squonk2 integration) read **`ARCHITECTURE.md`** — that is
+the document to consult before changing models, security, or the loader.
+
+## Commands
+
+Dependencies are managed with **Poetry** (`pyproject.toml` / `poetry.lock`). The
+application is intended to run inside its Docker container, not on the host.
+
+### Run locally
+```bash
+docker-compose up -d          # builds/starts backend + postgres + neo4j + redis
+docker-compose exec backend bash   # shell into the running backend
+docker-compose down
+```
+The API is then at `http://localhost:8080/api/`. The repo is bind-mounted into the
+container at `/code`, so host edits are live (no rebuild needed). Logs:
+`./data/logs/backend.log`. Locally, Celery runs **synchronously**
+(`CELERY_TASK_ALWAYS_EAGER=True`); to exercise real async tasks add the celery
+compose file: `docker compose -f docker-compose.yml -f docker-compose.celery.yml up`.
+
+### Migrations
+Use the dedicated migration compose file and run `makemigrations` *inside* the
+container (migrations are written back to the host via the bind mount, then commit
+them):
+```bash
+docker compose -f docker-compose-migrate.yml up -d
+docker compose -f docker-compose-migrate.yml exec backend bash
+python manage.py makemigrations viewer --name "descriptive_name"
+```
+
+### Lint / format
+Enforced via **pre-commit**:
+```bash
+pre-commit run --all-files
+```
+Important: linting is intentionally **limited to the `viewer` app** (see
+`.pre-commit-config.yaml`). Migrations are excluded from all hooks.
+
+## Conventions and gotchas
+
+- **Settings are environment-driven.** Almost all runtime configuration lives in
+  `fragalysis/settings.py`, read from environment variables. Read the comment block
+  at the top of that file for the style guide before adding a new variable. Not all
+  settings are dynamic (e.g. `ALLOWED_HOSTS` is static).
+- **Deployment mode** (`DEPLOYMENT_MODE` = `DEVELOPMENT` | `PRODUCTION`) changes
+  behaviour — production is stricter. Use `api.utils.deployment_mode_is_production()`
+  rather than reading the env var directly.
+- **Access control is not optional.** API views that expose project data subclass
+  `api.security.ISPyBSafeQuerySet` and declare `filter_permissions` so results are
+  filtered to the user's accessible proposals. Don't bypass this when adding views —
+  see `ARCHITECTURE.md` § Access control.
+- **"Infections"** (`api/infections.py`) let you inject specific error paths for
+  testing via the `INFECTIONS` env var; they are ignored in production mode.
+- **Conventional Commits** are used for commit messages.
+
+## Key directories
+
+- `fragalysis/` — the Django *project* (settings, root URLs, celery, wsgi, auth).
+- `viewer/` — the core app: models, DRF views/serializers, the target loader,
+  computed-set upload, Squonk2 job handling, tasks, tags. The bulk of the logic.
+- `api/` — cross-cutting concerns: security/access-control, infections, the target-
+  access (TA) auth connector.
+- `scoring/`, `hotspots/`, `hypothesis/`, `network/`, `media_serve/` — smaller apps.
+- `service_status/` — scheduled external-service health checks.
+- `design_docs/` — historical design documents (PDF + PlantUML) explaining *why*
+  major features were built; useful background, not kept in sync with code.
+- `docs/` — Sphinx source for the ReadTheDocs site.


### PR DESCRIPTION
## Summary
Adds developer/agent-facing documentation and Claude Code project configuration to the repo.

## Changes
- **ARCHITECTURE.md** — big-picture design doc (domain model, access control, async tasks, target-loading pipeline, Squonk2 integration).
- **CLAUDE.md** — project instructions for Claude Code (commands, conventions, key directories).
- **.claude/** — project config: `settings.json` and the `build-stack` skill.
- **.gitignore** — additional ignore entries.

Documentation/tooling only — no application code or behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)