### PR TITLE
feat(932): detect DownloadLinks that will not "finish"

### DIFF
--- a/api/infections.py
+++ b/api/infections.py
@@ -14,11 +14,14 @@ from api.utils import deployment_mode_is_production
 # Must be lowercase, but user can use any case in the environment variable.
 # Define every name as a constant, and add it and a description to the _CATALOGUE.
 INFECTION_STRUCTURE_DOWNLOAD: str = 'structure-download'
+INFECTION_STRUCTURE_DOWNLOAD_TASK: str = 'structure-download-task'
 
 # The index is the short-form name of the infection, and the value is the
 # description of the infection.
 _CATALOGUE: Dict[str, str] = {
-    INFECTION_STRUCTURE_DOWNLOAD: 'An error in the DownloadStructures view'
+    INFECTION_STRUCTURE_DOWNLOAD: 'An error in the DownloadStructures view',
+    INFECTION_STRUCTURE_DOWNLOAD_TASK: 'A crash in the download task (after it has'
+    ' started but before the file is built), to simulate a lost/stuck download',
 }
 
 

--- a/fragalysis/settings.py
+++ b/fragalysis/settings.py
@@ -577,10 +577,16 @@ HARD_EXPIRY_GRACE_PERIOD_M: int = int(
 DOWNLOAD_CLEANUP_INTERVAL_M: int = int(
     os.environ.get("DOWNLOAD_CLEANUP_INTERVAL_M", "4")
 )
-# Records that never had a keep_zip_until set are considered abandoned once
-# their create_date is older than this many minutes — the soft-erase pass
-# expires them so the hard-erase pass can clean them up.
-DOWNLOAD_ORPHAN_GRACE_M: int = int(os.environ.get("DOWNLOAD_ORPHAN_GRACE_M", "6"))
+# A download task is given this many minutes to start (set its task_id and begin
+# updating its status) before the "lost task" housekeeping pass will consider it.
+DOWNLOAD_TASK_START_GRACE_M: int = int(
+    os.environ.get("DOWNLOAD_TASK_START_GRACE_M", "4")
+)
+# The longest a download task is allowed to run before it is presumed lost (e.g.
+# the worker was restarted, leaving the Celery result frozen "in progress").
+DOWNLOAD_TASK_MAX_RUNTIME_M: int = int(
+    os.environ.get("DOWNLOAD_TASK_MAX_RUNTIME_M", "60")
+)
 
 # Some Squonk2 developer/debug variables.
 # Unused in production.

--- a/viewer/download_structures.py
+++ b/viewer/download_structures.py
@@ -25,12 +25,14 @@ import humanize
 import pandas as pd
 import pandoc
 import requests
+from celery.result import AsyncResult
 from django.conf import settings
-from django.db.models import Exists, F, OuterRef, Q, Value
+from django.db.models import Exists, F, OuterRef, Value
 from django.db.models.fields import CharField
 from django.db.models.functions import Concat
 from rdkit import Chem
 
+from api.infections import INFECTION_STRUCTURE_DOWNLOAD_TASK, have_infection
 from viewer.models import DownloadLinks, SiteObservation
 from viewer.utils import clean_filename
 
@@ -43,9 +45,12 @@ logger = logging.getLogger(__name__)
 KEEP_UNTIL_DURATION = timedelta(minutes=settings.DOWNLOAD_KEEP_UNTIL_DURATION_M)
 # Length of time to "expired" records
 HARD_EXPIRY_GRACE_PERIOD = timedelta(minutes=settings.HARD_EXPIRY_GRACE_PERIOD_M)
-# Records that never got a keep_zip_until set are treated as abandoned once
-# create_date is older than this; the soft-erase pass expires them.
-ORPHAN_GRACE_PERIOD = timedelta(minutes=settings.DOWNLOAD_ORPHAN_GRACE_M)
+# An in-progress download is given this long to start before the "lost task"
+# housekeeping pass will consider it (see expire_lost_download_records).
+TASK_START_GRACE_PERIOD = timedelta(minutes=settings.DOWNLOAD_TASK_START_GRACE_M)
+# The longest an in-progress download may run before it is presumed lost (e.g.
+# the worker was restarted, leaving the Celery result frozen "in progress").
+TASK_MAX_RUNTIME = timedelta(minutes=settings.DOWNLOAD_TASK_MAX_RUNTIME_M)
 
 # Filepaths mapping for writing associated files to the zip archive.
 # Note that if this is set to 'aligned' then the files will be placed in
@@ -1326,6 +1331,11 @@ def create_download(download_link_id: int, task, use_zip: bool = False):
     download_link.task_id = str(task.request.id)
     download_link.save()
 
+    # Simulate a worker crashing mid-build (task_id set, but file_url never written)
+    # so the "lost task" housekeeping can be exercised. Ignored in production.
+    if have_infection(INFECTION_STRUCTURE_DOWNLOAD_TASK):
+        raise RuntimeError(f'Download Error! ({INFECTION_STRUCTURE_DOWNLOAD_TASK})')
+
     # error checking is not necessary because all these objects are
     # already resolved in the view and then passed through task
     site_observations = SiteObservation.objects.filter(
@@ -1426,21 +1436,15 @@ def soft_erase_out_of_date_download_records():
     not already been soft-deleted (i.e. where an 'expired_date' is not set)
     and we set the 'expired_date'.
 
-    A record is considered out of date when either:
-
-    - its keep_zip_until is in the past, or
-    - keep_zip_until was never set and the record was created more than
-      ORPHAN_GRACE_PERIOD ago (treated as abandoned).
+    A record is considered out of date when its keep_zip_until is in the past.
+    In-progress records (keep_zip_until still null) are handled separately by
+    expire_lost_download_records(), which inspects the Celery task.
 
     Users should not use records that have an expired date.
     """
     now: datetime = datetime.now(timezone.utc)
-    orphan_cutoff = now - ORPHAN_GRACE_PERIOD
     new_expired_records = (
-        DownloadLinks.objects.filter(
-            Q(keep_zip_until__lt=now)
-            | Q(keep_zip_until__isnull=True, create_date__lt=orphan_cutoff)
-        )
+        DownloadLinks.objects.filter(keep_zip_until__lt=now)
         .filter(expired_date__isnull=True)
         .filter(static_link=False)
     )
@@ -1448,6 +1452,84 @@ def soft_erase_out_of_date_download_records():
     if num_expired := new_expired_records.update(expired_date=now):
         msg = "1 record has" if num_expired == 1 else f"{num_expired} records have"
         logger.info('%s now expired', msg)
+
+
+def expire_lost_download_records():
+    """Find in-progress download records whose Celery task will never finish and
+    expire them, recording a human-readable reason.
+
+    An in-progress record is one that has not yet been given a keep_zip_until
+    (that is only set when create_download() completes) and has not already been
+    expired. Such a record can be left "stuck" forever if its task crashed or its
+    worker was rebooted before it could write file_url / keep_zip_until.
+
+    Each candidate is given TASK_START_GRACE_PERIOD to get going, then its task is
+    inspected:
+
+    - no task_id ........ the task was never launched -> lost
+    - FAILURE / REVOKED . the task ended badly -> lost
+    - PENDING ........... no worker picked it up, or the result was lost -> lost
+    - still running ..... left alone, unless it has been running longer than
+                          TASK_MAX_RUNTIME (a frozen result implies a lost worker)
+
+    Users querying a lost task see the reason via TaskStatusView.
+    """
+    now: datetime = datetime.now(timezone.utc)
+    start_cutoff = now - TASK_START_GRACE_PERIOD
+    runtime_cutoff = now - TASK_MAX_RUNTIME
+
+    in_progress_records = (
+        DownloadLinks.objects.filter(keep_zip_until__isnull=True)
+        .filter(expired_date__isnull=True)
+        .filter(static_link=False)
+    )
+
+    num_lost = 0
+    for record in in_progress_records:
+        # Give the task a chance to start before we judge it.
+        if record.create_date > start_cutoff:
+            continue
+
+        reason: str | None = None
+        if not record.task_id:
+            reason = "The download task was never launched"
+        else:
+            result = AsyncResult(str(record.task_id))
+            state = result.state
+            if state in ('FAILURE', 'REVOKED'):
+                detail = result.info if isinstance(result.info, str) else state
+                reason = f"The download task ended unexpectedly ({detail})"
+            elif state == 'PENDING':
+                reason = (
+                    "The download task was lost"
+                    " (no worker result - it may never have run)"
+                )
+            elif record.create_date < runtime_cutoff:
+                runtime_m = settings.DOWNLOAD_TASK_MAX_RUNTIME_M
+                reason = (
+                    f"The download task exceeded the maximum runtime ({runtime_m} min)"
+                    " and is presumed lost (e.g. the worker was restarted)"
+                )
+
+        if reason:
+            record.expired_date = now
+            record.expiry_reason = reason
+            record.save(update_fields=['expired_date', 'expiry_reason'])
+            logger.info(
+                "Expired lost download (pk=%s task=%s): %s",
+                record.pk,
+                record.task_id,
+                reason,
+            )
+            num_lost += 1
+
+    if num_lost:
+        msg = (
+            "1 lost download has"
+            if num_lost == 1
+            else f"{num_lost} lost downloads have"
+        )
+        logger.info('%s now been expired', msg)
 
 
 def hard_erase_out_of_date_download_records():

--- a/viewer/management/commands/start_download_cleanup.py
+++ b/viewer/management/commands/start_download_cleanup.py
@@ -1,8 +1,10 @@
-"""Using the service status scheduler we install two tasks that run regularly to
+"""Using the service status scheduler we install three tasks that run regularly to
 clean-up "out od date" DownloadLinks records.
 
 A soft removal marks records as "expired" and a hard removal removes the underlying
-files for "expired" records that have been expired for a significant time.
+files for "expired" records that have been expired for a significant time. The
+"lost task" removal expires in-progress records whose Celery task has crashed or
+been lost (so they will never finish).
 """
 import signal
 
@@ -11,6 +13,7 @@ from django.core.management.base import BaseCommand
 
 import service_status.scheduler as scheduler_module
 from viewer.download_structures import (
+    expire_lost_download_records,
     hard_erase_out_of_date_download_records,
     soft_erase_out_of_date_download_records,
 )
@@ -39,6 +42,11 @@ class Command(BaseCommand):
         scheduler_module.add_service_job(
             'download_cleanup.hard_erase',
             hard_erase_out_of_date_download_records,
+            _INTERVAL_S,
+        )
+        scheduler_module.add_service_job(
+            'download_cleanup.expire_lost',
+            expire_lost_download_records,
             _INTERVAL_S,
         )
         scheduler_module.start()

--- a/viewer/migrations/0157_downloadlinks_expiry_reason.py
+++ b/viewer/migrations/0157_downloadlinks_expiry_reason.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('viewer', '0156_userrole'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='downloadlinks',
+            name='expiry_reason',
+            field=models.TextField(
+                help_text='Why the download was expired (e.g. the task was lost).'
+                ' Shown to users querying a failed download.',
+                null=True,
+            ),
+        ),
+    ]

--- a/viewer/models.py
+++ b/viewer/models.py
@@ -1609,6 +1609,11 @@ class DownloadLinks(models.Model):
         null=True,
         help_text="Set when the download file has been removed from the filesystem.",
     )
+    expiry_reason = models.TextField(
+        null=True,
+        help_text="Why the download was expired (e.g. the task was lost)."
+        " Shown to users querying a failed download.",
+    )
     # TODO - zip_file is no longer Used (A.Christie 2024-01-19)
     zip_file = models.BooleanField(default=False)
     original_search = models.JSONField(encoder=DjangoJSONEncoder, null=True)

--- a/viewer/tests/test_download_housekeeping.py
+++ b/viewer/tests/test_download_housekeeping.py
@@ -1,0 +1,187 @@
+"""Tests for the "lost download" housekeeping (ticket #932).
+
+``expire_lost_download_records`` inspects in-progress DownloadLinks records (those
+without a ``keep_zip_until``) and expires the ones whose Celery task has crashed or
+been lost, recording a human-readable ``expiry_reason``. ``TaskStatusView`` then
+surfaces that reason so a user polling a dead download gets a meaningful error.
+
+The single external seam is the Celery result backend, reached via
+``viewer.download_structures.AsyncResult`` - patched here so no broker/worker is
+needed. The start-grace / max-runtime windows use the settings defaults (4 / 60 min).
+"""
+# pylint: disable=redefined-outer-name,unused-argument
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from django.urls import reverse
+
+from viewer import download_structures
+from viewer.models import DownloadLinks
+
+
+def _make_link(
+    create_date, *, task_id="task-1", keep_zip_until=None, static_link=False
+):
+    return DownloadLinks.objects.create(
+        task_id=task_id,
+        create_date=create_date,
+        keep_zip_until=keep_zip_until,
+        static_link=static_link,
+    )
+
+
+def _patch_state(mocker, state, info=None):
+    """Make AsyncResult(...).state/.info return the given values."""
+    result = mocker.Mock()
+    result.state = state
+    result.info = info
+    return mocker.patch.object(download_structures, "AsyncResult", return_value=result)
+
+
+@pytest.fixture
+def now():
+    return datetime.now(timezone.utc)
+
+
+@pytest.mark.django_db
+def test_within_start_grace_is_left_alone(mocker, now):
+    """A young record is given time to start - not even queried."""
+    async_result = _patch_state(mocker, "PENDING")
+    link = _make_link(now - timedelta(minutes=1))
+
+    download_structures.expire_lost_download_records()
+
+    link.refresh_from_db()
+    assert link.expired_date is None
+    assert link.expiry_reason is None
+    async_result.assert_not_called()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("state", ["FAILURE", "REVOKED"])
+def test_failed_task_is_expired(mocker, now, state):
+    _patch_state(mocker, state, info="boom")
+    link = _make_link(now - timedelta(minutes=10))
+
+    download_structures.expire_lost_download_records()
+
+    link.refresh_from_db()
+    assert link.expired_date is not None
+    assert link.expiry_reason
+    assert "ended unexpectedly" in link.expiry_reason
+
+
+@pytest.mark.django_db
+def test_pending_task_is_expired_as_lost(mocker, now):
+    """PENDING past the grace means no worker result - the task is lost."""
+    _patch_state(mocker, "PENDING")
+    link = _make_link(now - timedelta(minutes=10))
+
+    download_structures.expire_lost_download_records()
+
+    link.refresh_from_db()
+    assert link.expired_date is not None
+    assert "lost" in link.expiry_reason.lower()
+
+
+@pytest.mark.django_db
+def test_running_within_max_runtime_is_left_alone(mocker, now):
+    """A genuinely long-running download must not be killed prematurely."""
+    _patch_state(mocker, "PROCESSING")
+    link = _make_link(now - timedelta(minutes=10))
+
+    download_structures.expire_lost_download_records()
+
+    link.refresh_from_db()
+    assert link.expired_date is None
+    assert link.expiry_reason is None
+
+
+@pytest.mark.django_db
+def test_running_beyond_max_runtime_is_expired(mocker, now):
+    """A 'running' task older than the max runtime is presumed lost (frozen
+    result after a worker restart)."""
+    _patch_state(mocker, "PROCESSING")
+    link = _make_link(now - timedelta(minutes=90))
+
+    download_structures.expire_lost_download_records()
+
+    link.refresh_from_db()
+    assert link.expired_date is not None
+    assert "maximum runtime" in link.expiry_reason
+
+
+@pytest.mark.django_db
+def test_no_task_id_is_expired(mocker, now):
+    """A record past the grace that never got a task_id was never launched."""
+    async_result = _patch_state(mocker, "PENDING")
+    link = _make_link(now - timedelta(minutes=10), task_id=None)
+
+    download_structures.expire_lost_download_records()
+
+    link.refresh_from_db()
+    assert link.expired_date is not None
+    assert "never launched" in link.expiry_reason
+    async_result.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_completed_record_is_not_a_candidate(mocker, now):
+    """A record with keep_zip_until set has finished and is ignored here."""
+    async_result = _patch_state(mocker, "FAILURE")
+    link = _make_link(
+        now - timedelta(minutes=10), keep_zip_until=now + timedelta(minutes=30)
+    )
+
+    download_structures.expire_lost_download_records()
+
+    link.refresh_from_db()
+    assert link.expired_date is None
+    async_result.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_static_link_is_left_alone(mocker, now):
+    async_result = _patch_state(mocker, "FAILURE")
+    link = _make_link(now - timedelta(minutes=10), static_link=True)
+
+    download_structures.expire_lost_download_records()
+
+    link.refresh_from_db()
+    assert link.expired_date is None
+    async_result.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_soft_erase_ignores_in_progress_records(now):
+    """soft_erase no longer time-expires in-progress (keep_zip_until null)
+    records - that is now expire_lost_download_records' job."""
+    link = _make_link(now - timedelta(hours=2))
+
+    download_structures.soft_erase_out_of_date_download_records()
+
+    link.refresh_from_db()
+    assert link.expired_date is None
+
+
+@pytest.mark.django_db
+def test_task_status_view_returns_recorded_reason(api_client, now):
+    """A user querying a lost download gets the stored reason as a FAILED status,
+    even with no live Celery result."""
+    task_id = uuid.uuid4()
+    DownloadLinks.objects.create(
+        task_id=str(task_id),
+        create_date=now,
+        expired_date=now,
+        expiry_reason="The download task was lost (no worker result)",
+    )
+
+    url = reverse("viewer:task_status", kwargs={"task_id": task_id})
+    response = api_client.get(url)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "FAILED"
+    assert body["finished"] is True
+    assert body["messages"] == ["The download task was lost (no worker result)"]

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -2175,6 +2175,26 @@ class TaskStatusView(APIView):
 
         # task_id is a UUID, but Celery expects a string
         task_id_str = str(task_id)
+
+        # If a download with this task was expired because its task was lost
+        # (see viewer.download_structures.expire_lost_download_records) the Celery
+        # result may be long gone, so return the recorded reason directly. This is
+        # the meaningful error the user should see on their next query.
+        lost_link = models.DownloadLinks.objects.filter(
+            task_id=task_id_str,
+            expired_date__isnull=False,
+            expiry_reason__isnull=False,
+        ).first()
+        if lost_link:
+            return JsonResponse(
+                {
+                    'started': True,
+                    'finished': True,
+                    'status': 'FAILED',
+                    'messages': [lost_link.expiry_reason],
+                }
+            )
+
         result = None
         try:
             result = AsyncResult(task_id_str)


### PR DESCRIPTION
Closes #932.

## Problem
When a target-download Celery task crashes (e.g. the badly-formatted-template era) or its worker is rebooted, the `DownloadLinks` record is left "stuck": `task_id` is set but `file_url`/`keep_zip_until` (written only at the very end of `create_download`) never are. The user polling the task gets no meaningful answer, and the record lingers.

The blunt time-based guard that existed (`soft_erase` expiring any `keep_zip_until IS NULL` record after `DOWNLOAD_ORPHAN_GRACE_M`=6 min) also **wrongly expired legitimately long downloads** — once expired, the `in_progress_link` lookup in `DownloadStructureView` no longer matched, so a *duplicate* task was launched for a download still building. It recorded no reason either.

## Change
Replace the orphan rule with a **Celery-task-status-aware** housekeeping pass, `expire_lost_download_records()`, scheduled alongside the existing soft/hard erase jobs (so it runs on `stack-0` only, at the same `DOWNLOAD_CLEANUP_INTERVAL_M` cadence).

For each in-progress record (`keep_zip_until` null, not expired, non-static), after a start grace it inspects the task via `AsyncResult(task_id)`:
- no `task_id` → never launched → lost
- `FAILURE`/`REVOKED` → lost
- `PENDING` → no worker result → lost
- still running → **left alone**, unless `create_date` exceeds a max-runtime cap (catches a worker rebooted mid-build, leaving the result frozen in `PROCESSING`)

Expiring sets `expired_date` **and** a human-readable `expiry_reason` (new field + migration `0157`). `TaskStatusView` now looks the record up by `task_id` and returns `status: FAILED` with that reason — working even after the Celery result has been evicted (the original failure mode).

`soft_erase_out_of_date_download_records()` now only handles completed (`keep_zip_until` set) records; the hard-erase pass is unchanged and cleans these up as before.

## Settings
- New: `DOWNLOAD_TASK_START_GRACE_M` (default 4), `DOWNLOAD_TASK_MAX_RUNTIME_M` (default 60)
- Removed: `DOWNLOAD_ORPHAN_GRACE_M` (now unused)

## Testing
- Added `viewer/tests/test_download_housekeeping.py` (11 tests, `AsyncResult` mocked) covering every branch above plus the `TaskStatusView` reason surfacing. Full suite: **49 passed, 1 skipped**; pre-commit clean.
- Added a `structure-download-task` infection that crashes the task after `task_id` is set but before the file is built, to reproduce a stuck record on demand for end-to-end verification (set `INFECTIONS=structure-download-task`, POST a download, run/await the housekeeping pass, then GET the `task_status_url`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)