### PR TITLE
fix(935): use default temp location instead of MEDIA_ROOT

### DIFF
--- a/viewer/management/commands/restore_v3_files_from_v2_archive.py
+++ b/viewer/management/commands/restore_v3_files_from_v2_archive.py
@@ -43,7 +43,11 @@ class Command(BaseCommand):
                     target.zip_archive.name,
                     exp_upload.file.name,
                 )
-                with TemporaryDirectory(dir='/tmp/') as decompress_dir:
+                # Use the default temporary location (an emptyDir mounted at
+                # /tmp within the Pod) rather than the shared MEDIA_ROOT volume;
+                # restored files are copied into MEDIA_ROOT with shutil.copy().
+                # See ticket #935.
+                with TemporaryDirectory() as decompress_dir:
                     process = subprocess.Popen(
                         [
                             "tar",

--- a/viewer/target_loader.py
+++ b/viewer/target_loader.py
@@ -3784,7 +3784,12 @@ def load_target(
     user_id=None,
     task=None,
 ):
-    with TemporaryDirectory(dir=settings.MEDIA_ROOT) as tempdir:
+    # A temporary working directory for decompressing the uploaded bundle.
+    # This lives within the Pod (the default location, an emptyDir mounted at
+    # /tmp), not the (potentially slow) shared MEDIA_ROOT volume. The extracted
+    # data is moved to its final MEDIA_ROOT location with shutil.move(), which
+    # copes with a cross-filesystem move. See ticket #935.
+    with TemporaryDirectory() as tempdir:
         target_loader = TargetLoader(
             data_bundle, proposal_ref, tempdir, user_id=user_id, task=task
         )


### PR DESCRIPTION
Closes #935

## What

Stop using the shared `MEDIA_ROOT` volume as the location for transient temporary directories. Pods now have an `emptyDir` mounted at `/tmp`, so temp dirs used purely as in-Pod scratch space should rely on the default `tempfile` location.

## Changes

- **`viewer/target_loader.py`** (`load_target`): `TemporaryDirectory(dir=settings.MEDIA_ROOT)` → `TemporaryDirectory()`. The temp dir is just a decompression workspace; extracted data still reaches `MEDIA_ROOT` via `shutil.move()`, which handles the cross-filesystem move. The other transfer, `Path(bundle_path).rename(...)`, is media→media (the uploaded bundle lives at `MEDIA_ROOT/tmp/...`) and is unaffected.
- **`viewer/management/commands/restore_v3_files_from_v2_archive.py`**: dropped the hard-coded `dir='/tmp/'` in favour of the default; restored files are copied into `MEDIA_ROOT` with `shutil.copy()` (cross-device safe).

## Deliberately left alone

`viewer/views.py` stages the uploaded bundle under `MEDIA_ROOT/tmp` (with a "cannot use TemporaryDirectory here because task" comment). That file must persist across the Celery task boundary (shared volume between web and worker Pods), so it correctly cannot use an in-Pod temp dir — exactly the exception the ticket calls out.

## Testing

No behavioural change (only the on-disk location of scratch space), and no existing test asserts on these temp-dir locations. Pre-commit (`black`/`isort`/`mypy`/`pylint`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)