### PR TITLE
fix(937): handle keycloak request timeout without noisy traceback

### DIFF
--- a/service_status/services.py
+++ b/service_status/services.py
@@ -101,6 +101,10 @@ def keycloak() -> str:
     keycloak_realm = settings.OIDC_KEYCLOAK_REALM
     if not keycloak_realm:
         return State.NOT_CONFIGURED
-    response = requests.get(keycloak_realm, timeout=REQUEST_TIMEOUT_S)
+    try:
+        response = requests.get(keycloak_realm, timeout=REQUEST_TIMEOUT_S)
+    except requests.exceptions.RequestException as r_ex:
+        logger.error('Keycloak GET:%s RequestException (%s)', keycloak_realm, r_ex)
+        return State.DEGRADED
     logger.debug("keycloak response: %s", response)
     return State.OK if response.ok else State.DEGRADED


### PR DESCRIPTION
Closes #937

## Problem
On the V2 production stack (stack-0), the `service_status` scheduler's periodic Keycloak ping dumps a full multi-frame traceback to stdout whenever the request to the realm URL (`identity.diamond.ac.uk`) times out.

`service_status/services.py::keycloak()` called `requests.get(...)` with no exception handling. The 5s request timeout fires well before the `service_query` decorator's 28s soft limit, so the resulting `requests.exceptions.ReadTimeout` propagates out of the function, past the decorator (which only catches `concurrent.futures.TimeoutError`), and into APScheduler's `run_job`, which logs the entire traceback.

## Fix
Catch `requests.exceptions.RequestException` inside `keycloak()`, log a single concise line, and return `State.DEGRADED`. This mirrors the existing succinct pattern in `api.ta_auth_connector.get_auth_ping()` referenced in the ticket.

## Notes
- Per-function handling (not the centralized decorator) and `DEGRADED` state were confirmed as the preferred approach.
- `service_status` is outside the pre-commit lint scope (`viewer` only) and has no pytest suite (`testpaths = viewer/tests`), so no automated test is added. `pre-commit` passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
