### PR TITLE
fix(939): render non-finite Experiment floats as null

### DIFF
--- a/viewer/serializers.py
+++ b/viewer/serializers.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from pathlib import Path
 from urllib.parse import urljoin
 
@@ -1101,6 +1102,18 @@ class ExperimentReadSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Experiment
         fields = '__all__'
+
+    def to_representation(self, instance):
+        # SoakDB-sourced float fields (e.g. resolution/refinement metrics) can
+        # hold NaN/inf, which DRF's strict JSON renderer refuses to encode
+        # ("Out of range float values are not JSON compliant"), 500ing the
+        # endpoint. Map any non-finite float to null so we emit valid JSON.
+        # See ticket #939.
+        ret = super().to_representation(instance)
+        for key, value in ret.items():
+            if isinstance(value, float) and not math.isfinite(value):
+                ret[key] = None
+        return ret
 
 
 class CanonSiteConfReadSerializer(serializers.ModelSerializer):

--- a/viewer/tests/test_experiment_serialization.py
+++ b/viewer/tests/test_experiment_serialization.py
@@ -1,0 +1,60 @@
+"""Regression test for ticket #939.
+
+SoakDB-sourced ``FloatField``s on ``Experiment`` can hold ``NaN`` (Postgres
+stores it happily). DRF's JSON renderer runs in strict mode (``allow_nan=False``)
+and raises ``ValueError: Out of range float values are not JSON compliant: nan``
+when rendering, which surfaced as a 500 on ``/api/experiments/``.
+
+``ExperimentReadSerializer`` now maps non-finite floats to ``null`` so the
+endpoint renders valid JSON instead of erroring.
+"""
+# Fixtures legitimately reuse their names as arguments, and the `db` fixture is
+# requested for its side effect only - both are standard pytest patterns that
+# pylint misreads.
+# pylint: disable=redefined-outer-name,unused-argument
+from datetime import datetime
+from datetime import timezone as dt_timezone
+
+import pytest
+
+from viewer.models import Experiment, ExperimentUpload
+
+
+@pytest.fixture
+def make_experiment(db):
+    """Factory creating an Experiment (and its required ExperimentUpload)."""
+
+    def _make_experiment(project, target, committer, **fields):
+        upload = ExperimentUpload.objects.create(
+            project=project,
+            target=target,
+            file="experiment-upload/dummy.tgz",
+            commit_datetime=datetime(2026, 1, 1, tzinfo=dt_timezone.utc),
+            committer=committer,
+        )
+        return Experiment.objects.create(experiment_upload=upload, **fields)
+
+    return _make_experiment
+
+
+def test_experiments_list_renders_nan_float_as_null(
+    authenticated_client, user, make_project, make_target, make_experiment
+):
+    """A NaN float field renders as JSON null, not a 500."""
+    project = make_project("members-only", members=[user])
+    target = make_target(project)
+    make_experiment(
+        project,
+        target,
+        committer=user,
+        code="x0001",
+        dimple_rfree=float("nan"),
+    )
+
+    response = authenticated_client.get("/api/experiments/")
+
+    assert response.status_code == 200
+    # render the payload to confirm strict JSON encoding succeeds end-to-end
+    response.render()
+    (row,) = response.data["results"]
+    assert row["dimple_rfree"] is None


### PR DESCRIPTION
Closes #939

## Problem
On the production stack (stack-2), `GET /api/experiments/` intermittently 500s with:

```
ValueError: Out of range float values are not JSON compliant: nan
```

**Cause:** several `FloatField`s on the `Experiment` model (resolution/refinement metrics loaded from SoakDB, e.g. `dimple_rfree`, `high_resolution`, `cchalf_overall`) can hold `NaN`. Postgres stores `NaN` in a `double precision` column without complaint, but DRF's JSON renderer runs in strict mode (`allow_nan=False`), so `json.dumps` raises `ValueError` while rendering the response — surfacing as an Internal Server Error.

## Fix
Override `ExperimentReadSerializer.to_representation` to map any non-finite float (`NaN`, `inf`, `-inf`) to `None`, so the endpoint emits valid JSON (`null`) instead of erroring.

Handling this at serialization (rather than at load time) means it also fixes **already-loaded production data** with no migration or data cleanup required.

## Test
Adds `viewer/tests/test_experiment_serialization.py`: creates an `Experiment` with `dimple_rfree=NaN`, hits `/api/experiments/`, and asserts a `200` with the field rendered as `null`. Verified it reproduces the exact ticket error without the fix and passes with it. Full viewer suite: `39 passed, 1 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
