### PR TITLE
fix: pose lookup error (cherry-pick of f852f987)

### DIFF
--- a/viewer/target_loader.py
+++ b/viewer/target_loader.py
@@ -2781,7 +2781,15 @@ class TargetLoader:
                     # I don't know if this can happen but this (due to
                     # other bugs) is what allowed me to find this
                     # error. Make a note in the logs.
-                    logger.warning("No observations left to assign to pose")
+                    logger.info(
+                        "No observations left to assign to pose from group %s",
+                        group,
+                    )
+                    # update: apparently can happen when user decides
+                    # to split apart existing group. in this case, all
+                    # observations are assigned to poses and there's
+                    # nothing to do. demoting log entry to info
+                    continue
 
             # finally add observations to the (new or existing) pose
             for obvs in pose_items:


### PR DESCRIPTION
Cherry-picks commit f852f987 ("fix: pose lookup error") from `staging` onto `production` in isolation, without bringing the rest of staging's unreleased changes.

## Change
`viewer/target_loader.py`: when there are no observations left to assign to a pose, demote the log entry from `warning` to `info` (with the source group included) and `continue`. This situation can legitimately occur when a user splits apart an existing group — all observations are already assigned to poses, so there is nothing to do.

## Notes
- Single-file, 9 insertions / 1 deletion.
- Cherry-pick applied cleanly onto `production` (no conflicts).
- The broader staging→production merge remains tracked separately in #945.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
