### PR TITLE
test: run unit tests with pytest on the host, no image build

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -48,6 +48,21 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       push: ${{ steps.vars.outputs.push }}
+    services:
+      # PostgreSQL (pgvector) for the unit tests. pytest connects on
+      # localhost:5432 - see tests/test_settings.py for the connection defaults.
+      database:
+        image: xchem/fragalysis-database:2026.04.1
+        env:
+          POSTGRES_PASSWORD: fragalysis
+          POSTGRES_DB: frag
+        ports:
+        - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d frag"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
     - name: Inject slug/short variables
       uses: rlespinasse/github-slug-action@v5
@@ -80,6 +95,19 @@ jobs:
       run: |
         pip install --requirement build-requirements.txt
         pre-commit run --all-files
+    - name: Set up Python (unit tests)
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.13'
+    - name: Install Poetry
+      run: pipx install poetry==2.1.4
+    - name: Install test dependencies
+      run: poetry install --only main,test --no-root --no-directory
+    - name: Unit tests (pytest)
+      # Runs on the host runner against the 'database' service container; the
+      # backend image is not needed. DB connection defaults live in
+      # tests/test_settings.py.
+      run: poetry run pytest
     - name: Docker build
       uses: docker/build-push-action@v6
       with:
@@ -107,14 +135,6 @@ jobs:
         ./osv-scanner scan image ${{ steps.vars.outputs.BE_NAMESPACE }}/fragalysis-backend:${{ env.GITHUB_REF_SLUG }} \
             --format markdown --output scan.md || true
         cat scan.md >> $GITHUB_STEP_SUMMARY
-    - name: Test (docker compose)
-      uses: hoverkraft-tech/compose-action@v2.4.2
-      with:
-        compose-file: ./docker-compose.test.yml
-        up-flags: --build --exit-code-from tests --abort-on-container-exit
-      env:
-        BE_NAMESPACE: ${{ steps.vars.outputs.BE_NAMESPACE }}
-        BE_IMAGE_TAG: ${{ env.GITHUB_REF_SLUG }}
     - name: Login to DockerHub
       if: steps.vars.outputs.push == 'true'
       uses: docker/login-action@v3

--- a/.github/workflows/build-production.yaml
+++ b/.github/workflows/build-production.yaml
@@ -55,6 +55,21 @@ jobs:
       push: ${{ steps.vars.outputs.push }}
       tag: ${{ steps.vars.outputs.tag }}
       trigger: ${{ steps.vars.outputs.trigger }}
+    services:
+      # PostgreSQL (pgvector) for the unit tests. pytest connects on
+      # localhost:5432 - see tests/test_settings.py for the connection defaults.
+      database:
+        image: xchem/fragalysis-database:2026.04.1
+        env:
+          POSTGRES_PASSWORD: fragalysis
+          POSTGRES_DB: frag
+        ports:
+        - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d frag"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
     - name: Inject slug/short variables
       uses: rlespinasse/github-slug-action@v5
@@ -127,6 +142,19 @@ jobs:
       run: |
         pip install --requirement build-requirements.txt
         pre-commit run --all-files
+    - name: Set up Python (unit tests)
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.13'
+    - name: Install Poetry
+      run: pipx install poetry==2.1.4
+    - name: Install test dependencies
+      run: poetry install --only main,test --no-root --no-directory
+    - name: Unit tests (pytest)
+      # Runs on the host runner against the 'database' service container; the
+      # backend image is not needed. DB connection defaults live in
+      # tests/test_settings.py.
+      run: poetry run pytest
     - name: Build
       uses: docker/build-push-action@v6
       with:
@@ -134,14 +162,6 @@ jobs:
         tags: |
           ${{ steps.vars.outputs.BE_NAMESPACE }}/fragalysis-backend:${{ steps.vars.outputs.tag }}
           ${{ steps.vars.outputs.BE_NAMESPACE }}/fragalysis-backend:stable
-    - name: Test (docker compose)
-      uses: hoverkraft-tech/compose-action@v2.4.2
-      with:
-        compose-file: ./docker-compose.test.yml
-        up-flags: --build --exit-code-from tests --abort-on-container-exit
-      env:
-        BE_NAMESPACE: ${{ steps.vars.outputs.BE_NAMESPACE }}
-        BE_IMAGE_TAG: ${{ steps.vars.outputs.tag }}
     - name: Login to DockerHub
       if: steps.vars.outputs.push == 'true'
       uses: docker/login-action@v3

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -77,6 +77,21 @@ jobs:
       push: ${{ steps.vars.outputs.push }}
       tag: ${{ steps.vars.outputs.tag }}
       trigger: ${{ steps.vars.outputs.trigger }}
+    services:
+      # PostgreSQL (pgvector) for the unit tests. pytest connects on
+      # localhost:5432 - see tests/test_settings.py for the connection defaults.
+      database:
+        image: xchem/fragalysis-database:2026.04.1
+        env:
+          POSTGRES_PASSWORD: fragalysis
+          POSTGRES_DB: frag
+        ports:
+        - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d frag"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
     - name: Inject slug/short variables
       uses: rlespinasse/github-slug-action@v5
@@ -149,19 +164,24 @@ jobs:
       run: |
         pip install --requirement build-requirements.txt
         pre-commit run --all-files
+    - name: Set up Python (unit tests)
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.13'
+    - name: Install Poetry
+      run: pipx install poetry==2.1.4
+    - name: Install test dependencies
+      run: poetry install --only main,test --no-root --no-directory
+    - name: Unit tests (pytest)
+      # Runs on the host runner against the 'database' service container; the
+      # backend image is not needed. DB connection defaults live in
+      # tests/test_settings.py.
+      run: poetry run pytest
     - name: Docker build
       uses: docker/build-push-action@v6
       with:
         context: .
         tags: ${{ steps.vars.outputs.BE_NAMESPACE }}/fragalysis-backend:${{ steps.vars.outputs.tag }}
-    - name: Test (docker compose)
-      uses: hoverkraft-tech/compose-action@v2.4.2
-      with:
-        compose-file: ./docker-compose.test.yml
-        up-flags: --build --exit-code-from tests --abort-on-container-exit
-      env:
-        BE_NAMESPACE: ${{ steps.vars.outputs.BE_NAMESPACE }}
-        BE_IMAGE_TAG: ${{ steps.vars.outputs.tag }}
     - name: Login to DockerHub
       if: steps.vars.outputs.push == 'true'
       uses: docker/login-action@v3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,28 @@ pre-commit run --all-files
 Important: linting is intentionally **limited to the `viewer` app** (see
 `.pre-commit-config.yaml`). Migrations are excluded from all hooks.
 
+### Run the unit tests
+The tests run with **pytest** in a host Poetry virtualenv — **no backend image
+build required** (this is what CI does too). They still need a real PostgreSQL
+(pgvector, simple_history); SQLite cannot stand in, so a database container is
+started for them. The simplest path:
+```bash
+poetry install --only main,test    # one-time: add pytest to the host venv
+./run-unit-tests.sh                 # starts the DB container, then runs pytest
+```
+`run-unit-tests.sh` passes any arguments through to pytest, e.g.
+`./run-unit-tests.sh viewer/tests/test_download_capacity.py -k expired`.
+
+To run pytest directly, start just the database and let the test-settings
+defaults point at it (`127.0.0.1:5432`):
+```bash
+docker compose -f docker-compose.test.yml up -d --wait database
+poetry run pytest
+```
+pytest config (settings module, `--reuse-db`, coverage) lives in
+`[tool.pytest.ini_options]` in `pyproject.toml`; test-only Django overrides are
+in `tests/test_settings.py`. Tests live in `viewer/tests/`.
+
 ## Conventions and gotchas
 
 - **Settings are environment-driven.** Almost all runtime configuration lives in

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,9 @@ COPY poetry.lock pyproject.toml /
 
 # POETRY_VIRTUALENVS_IN_PROJECT tells poetry to create the venv to
 # project's directory (.venv). This way the location is predictable.
-# The 'test' group is included so that 'pytest' is present in the image when
-# docker-compose.test.yml runs test-entry.sh (the same image is used for the
-# app and for tests).
-RUN POETRY_VIRTUALENVS_IN_PROJECT=true poetry install --no-root --only main,test --no-directory
+# Only the 'main' dependencies are installed - the unit tests run with pytest
+# on the host / CI runner (see run-unit-tests.sh), not inside this image.
+RUN POETRY_VIRTUALENVS_IN_PROJECT=true poetry install --no-root --only main --no-directory
 
 # final stage. only copy the venv with installed packages and point
 # paths to it

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,29 +1,18 @@
 ---
+# The database service used to run the unit tests on the host.
+#
+# The tests run with pytest in a host Poetry virtualenv (see run-unit-tests.sh
+# and the README "Run the unit tests" section) - they no longer run inside the
+# backend image. The schema needs a real PostgreSQL (pgvector, simple_history),
+# so start just this service and point pytest at localhost:5432:
+#
+#   docker compose -f docker-compose.test.yml up -d --wait database
+#   poetry run pytest
+#
+# Or simply run ./run-unit-tests.sh, which does both.
 services:
 
   database:
     extends:
       file: common-services.yml
       service: database
-
-  tests:
-    image: ${BE_NAMESPACE:-xchem}/fragalysis-backend:${BE_IMAGE_TAG:-latest}
-    command:
-    - /bin/bash
-    - /code/test-entry.sh
-    volumes:
-    - .:/code
-    - ../logs:/code/logs/
-    - ../media:/code/media/
-    environment:
-      CACHE_ENABLED: "No"
-      POSTGRESQL_DATABASE: frag
-      POSTGRESQL_USER: postgres
-      POSTGRESQL_PASSWORD: fragalysis
-      POSTGRESQL_HOST: database
-      POSTGRESQL_PORT: 5432
-    ports:
-    - "80:80"
-    depends_on:
-      database:
-        condition: service_healthy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,9 @@ httpie = "^3.2"
 black = "^25.9"
 mypy = "^1.18"
 
-# Test framework - installed into the (test) container image so that
-# 'pytest' is available when docker-compose.test.yml runs test-entry.sh.
-# See the Dockerfile 'poetry install --only main,test' line.
+# Test framework - the unit tests run with pytest in a host/CI Poetry
+# virtualenv (see run-unit-tests.sh), not inside the backend image. Install
+# with 'poetry install --only main,test'.
 [tool.poetry.group.test.dependencies]
 pytest = "^8.3"
 pytest-django = "^4.9"

--- a/run-unit-tests.sh
+++ b/run-unit-tests.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Run the backend unit tests on the host with pytest - no backend image build.
+#
+# The test schema needs a real PostgreSQL (pgvector, simple_history), so this
+# starts just the database container (not the backend image) and points pytest
+# at it. Any arguments are passed straight through to pytest, for example:
+#
+#   ./run-unit-tests.sh
+#   ./run-unit-tests.sh -k expired
+#   ./run-unit-tests.sh viewer/tests/test_download_capacity.py
+#
+# First-time setup (once): install the host virtualenv with
+#   poetry install --only main,test
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# Start only the PostgreSQL service (defined in docker-compose.test.yml) and
+# wait until it reports healthy. This neither builds nor needs the backend image.
+docker compose -f docker-compose.test.yml up --detach --wait database
+
+# Ensure pytest (the 'test' dependency group) is present in the host virtualenv.
+if ! poetry run python -c "import pytest" >/dev/null 2>&1; then
+    echo "Installing test dependencies into the Poetry virtualenv..."
+    poetry install --only main,test --no-root --no-directory
+fi
+
+# Connection details for the localhost database container. These match the
+# defaults in tests/test_settings.py and are set here only to be explicit.
+export POSTGRESQL_HOST=127.0.0.1
+export POSTGRESQL_PORT=5432
+export POSTGRESQL_DATABASE=frag
+export POSTGRESQL_USER=postgres
+export POSTGRESQL_PASSWORD=fragalysis
+export CACHE_ENABLED=No
+
+poetry run pytest "$@"

--- a/test-entry.sh
+++ b/test-entry.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# Entry point used by docker-compose.test.yml (and CI) to run the test suite.
-# pytest configuration lives in pyproject.toml ([tool.pytest.ini_options]),
-# including the test settings module and coverage options.
-set -e
-
-cd /code
-pytest

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -63,3 +63,16 @@ EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 # writable MEDIA_ROOT. The application default ("/code/media/") only exists in
 # the container, so use an isolated temp directory that also works on the host.
 MEDIA_ROOT = tempfile.mkdtemp(prefix="fragalysis-test-media-")
+
+# The application logging config writes to rotating files under BASE_DIR/logs,
+# a directory that only exists in the container (a mounted volume). Redirect
+# those files to a writable temp directory so the suite runs on a bare host / CI
+# checkout. (Skipped when DISABLE_LOGGING_FRAMEWORK leaves LOGGING undefined.)
+if "LOGGING" in globals():
+    _test_log_dir = tempfile.mkdtemp(prefix="fragalysis-test-logs-")
+    _handlers: dict = LOGGING["handlers"]  # type: ignore[assignment]  # noqa: F405
+    for _handler in _handlers.values():
+        if "filename" in _handler:
+            _handler["filename"] = os.path.join(
+                _test_log_dir, os.path.basename(_handler["filename"])
+            )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,11 +5,16 @@ This module imports everything from the normal application settings and then
 applies test-only overrides. It is selected via ``DJANGO_SETTINGS_MODULE`` in
 ``[tool.pytest.ini_options]`` (see ``pyproject.toml``).
 
-The database connection details still come from the environment
-(``POSTGRESQL_*``), which ``docker-compose.test.yml`` provides, because the
-schema requires a real PostgreSQL instance (pgvector, simple_history, etc.) -
-SQLite cannot stand in for it.
+The schema requires a real PostgreSQL instance (pgvector, simple_history, etc.)
+- SQLite cannot stand in for it - but it does not require the backend container
+image. By default we connect to a PostgreSQL on ``localhost`` (the ``database``
+service of ``docker-compose.test.yml``, or a CI service container), so the suite
+runs with a bare ``pytest`` on the host. The ``POSTGRESQL_*`` environment
+variables still override these defaults when supplied.
 """
+import os
+import tempfile
+
 from fragalysis.settings import *  # noqa: F401,F403
 
 # Run as a non-production deployment. Production mode is intentionally
@@ -35,9 +40,26 @@ TA_AUTH_QUERY_KEY = ""
 # settings are imported repeatedly under pytest. The schema is identical.
 DATABASES["default"]["ENGINE"] = "django.db.backends.postgresql"  # noqa: F405
 
+# Connect to a localhost PostgreSQL by default (the application settings default
+# to the docker-network name "database"/user "fragalysis"). This lets the suite
+# run on the host against the docker-compose.test.yml "database" container - or
+# a CI service container - without the backend image. An explicit POSTGRESQL_*
+# environment variable still wins.
+DATABASES["default"]["HOST"] = os.environ.get(
+    "POSTGRESQL_HOST", "127.0.0.1"
+)  # noqa: F405
+DATABASES["default"]["USER"] = os.environ.get(
+    "POSTGRESQL_USER", "postgres"
+)  # noqa: F405
+
 # Fast, insecure password hashing - we never need real hashing strength in
 # tests and this noticeably speeds up user creation.
 PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 
 # Don't try to talk to a real SMTP server; collect mail in memory instead.
 EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+
+# Tests that touch the media tree (create/delete sub-directories) need a
+# writable MEDIA_ROOT. The application default ("/code/media/") only exists in
+# the container, so use an isolated temp directory that also works on the host.
+MEDIA_ROOT = tempfile.mkdtemp(prefix="fragalysis-test-media-")


### PR DESCRIPTION
## Why

The unit tests previously ran only **inside the produced backend image** (via `docker-compose.test.yml` + `test-entry.sh`) — a historical arrangement that forced the image to carry the test dependencies and made any local run require a full image build.

The heavy dependencies (rdkit, psycopg, pgvector, pandas…) now install and import cleanly into a host Poetry virtualenv, so the tests can run with bare `pytest`. The only hard requirement is a real PostgreSQL (pgvector / simple_history — SQLite cannot substitute), which is supplied by a standalone DB container locally and a **service container** in CI.

## What changed

- **`tests/test_settings.py`** — default the DB connection to `localhost` (`127.0.0.1`, user `postgres`) and point `MEDIA_ROOT` at a temp dir, so `pytest` runs on the host (or a CI service container) without the backend image. `POSTGRESQL_*` env vars still override.
- **`run-unit-tests.sh`** (new) — convenience wrapper: starts only the database container, ensures the test deps, then runs `pytest` (args passed through).
- **`docker-compose.test.yml`** — reduced to the `database` service only; the image-based `tests` service and `test-entry.sh` are removed.
- **`Dockerfile`** — install only the `main` group (pytest no longer needed in the image).
- **CI (`build-dev` / `build-staging` / `build-production`)** — replace the in-image compose test step with **host pytest against a PostgreSQL service container**, run *before* the image build so it fails fast and is independent of it.
- **`CLAUDE.md`** — document the new "Run the unit tests" workflow.

## How to run locally

```bash
poetry install --only main,test    # one-time
./run-unit-tests.sh
```

## Verification

- Full suite on the host via `./run-unit-tests.sh`: **55 passed, 1 skipped**.
- Bare `poetry run pytest` with no env vars (the path CI relies on): passes.
- All three workflow YAMLs parse; DB service present, old compose step removed.
- pre-commit clean.

## Reviewer note — please watch the first CI run

The CI changes cannot be exercised locally. Two things to confirm on this PR run:
1. `poetry install --only main,test` resolving on `ubuntu-latest` (works on the macOS host; Linux wheels exist).
2. The `xchem/fragalysis-database:2026.04.1` service container coming up healthy under GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
