### PR TITLE
test: add code coverage reporting to pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,4 +99,16 @@ testpaths = ["viewer/tests"]
 #   pass --create-db explicitly when migrations change. CI containers are
 #   ephemeral so the first (and only) run always creates it.
 # --strict-markers: typo'd/unknown @pytest.mark markers become errors.
-addopts = "--reuse-db --strict-markers --cov=viewer --cov-report=term-missing"
+addopts = "--reuse-db --strict-markers --cov=viewer --cov-report=term-missing --cov-report=html"
+
+[tool.coverage.run]
+# Coverage measures the viewer app's hand-written code. Auto-generated
+# migrations (excluded from all lint hooks too) and the tests themselves
+# would otherwise distort the headline figure.
+omit = [
+    "viewer/migrations/*",
+    "viewer/tests/*",
+]
+
+[tool.coverage.html]
+directory = "htmlcov"


### PR DESCRIPTION
## What

Adds code coverage reporting to the pytest run.

- `pytest` now emits a **terminal summary** (with missing lines) and a **browsable HTML report** in `htmlcov/` (already gitignored).
- Auto-generated migrations (`viewer/migrations/*`, already excluded from all lint hooks) and the test files (`viewer/tests/*`) are omitted from the figure so it reflects hand-written `viewer` code.

## Current coverage

**32%** (8,904 statements, 6,051 missing) — 55 passed, 1 skipped.

View the report locally after a run:

```bash
open htmlcov/index.html
```

## Notes

No badge wiring is included — this is just the measurement + report. CI already runs `poetry run pytest`, so it picks up the new config with no workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)