### PR TITLE
test(953): broad REST API tests for an empty (no-Target) installation

### DIFF
--- a/viewer/tests/conftest.py
+++ b/viewer/tests/conftest.py
@@ -89,6 +89,25 @@ def authenticated_client(api_client, user) -> APIClient:
 
 
 @pytest.fixture
+def set_restricted_tas_users(settings) -> Callable[[str], None]:
+    """Simulate proposal membership via the RESTRICTED_TAS_USERS debug seam.
+
+    ``api.security.get_restricted_tas_user_proposal`` reads two settings that
+    the application derives from a single ``RESTRICTED_TAS_USERS`` environment
+    variable (see ``fragalysis.settings``): the raw string and its comma-split
+    list form. This fixture returns a setter that takes the same
+    ``"user:tas,user:tas"`` value the env var uses and applies it to both, so a
+    test can grant a user access to a proposal without any external service.
+    """
+
+    def _set(value: str) -> None:
+        settings.RESTRICTED_TAS_USERS = value
+        settings.RESTRICTED_TAS_USERS_LIST = value.split(",") if value else []
+
+    return _set
+
+
+@pytest.fixture
 def mock_target_access(monkeypatch) -> Callable[[Iterable[str]], None]:
     """Patch the single external access-control seam.
 

--- a/viewer/tests/test_empty_api.py
+++ b/viewer/tests/test_empty_api.py
@@ -1,0 +1,114 @@
+"""Broad smoke tests of the REST API against an *empty* installation.
+
+The database here has no ``Target`` (and therefore none of the experiment /
+site-observation / pose data that hangs off one). The point is breadth, not
+depth: confirm that the API as a whole behaves sanely with nothing loaded -
+list endpoints answer 200 with an empty, paginated result set; access control
+still applies; read-only viewsets stay read-only; and the supporting
+user/role endpoints respond as documented. Deep, data-driven assertions belong
+with the fixtures that load a real target archive, not here.
+"""
+
+import pytest
+
+# A deliberately broad slice of the access-controlled (ISPyBSafeQuerySet) list
+# endpoints. With an empty database each must answer 200 with an empty page,
+# whether or not the caller is authenticated - there is simply nothing to show.
+LIST_ENDPOINTS = [
+    "/api/targets/",
+    "/api/projects/",
+    "/api/compounds/",
+    "/api/experiments/",
+    "/api/target_experiment_uploads/",
+    "/api/site_observations/",
+    "/api/canon_sites/",
+    "/api/canon_site_confs/",
+    "/api/xtalform_sites/",
+    "/api/poses/",
+    "/api/session-projects/",
+    "/api/snapshots/",
+    "/api/compound-sets/",
+    "/api/tag_category/",
+    "/api/siteobservation_tag/",
+    "/api/session_project_tag/",
+]
+
+
+def _results(response):
+    """The result list from a LimitOffset-paginated response."""
+    assert "results" in response.data, response.data
+    return response.data["results"]
+
+
+@pytest.mark.parametrize("endpoint", LIST_ENDPOINTS)
+def test_list_endpoint_empty_for_authenticated_user(authenticated_client, endpoint):
+    """Every list endpoint is reachable and empty for an authenticated user."""
+    response = authenticated_client.get(endpoint)
+
+    assert response.status_code == 200
+    assert _results(response) == []
+    assert response.data["count"] == 0
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("endpoint", LIST_ENDPOINTS)
+def test_list_endpoint_empty_for_anonymous_user(api_client, endpoint):
+    """The same endpoints are reachable and empty for an anonymous caller.
+
+    Access control yields only public data to an anonymous user; with nothing
+    loaded that is, correctly, an empty page rather than an error.
+    """
+    response = api_client.get(endpoint)
+
+    assert response.status_code == 200
+    assert _results(response) == []
+
+
+def test_retrieve_missing_target_is_404(authenticated_client):
+    """Retrieving a non-existent record returns 404, not a server error."""
+    response = authenticated_client.get("/api/targets/999999/")
+
+    assert response.status_code == 404
+
+
+def test_readonly_viewset_rejects_post(authenticated_client):
+    """Projects are read-only over the API: POST is not allowed (405)."""
+    response = authenticated_client.post("/api/projects/", data={"title": "nope"})
+
+    assert response.status_code == 405
+
+
+def test_user_endpoint_reports_no_access_for_authenticated_user(authenticated_client):
+    """``/api/user/`` describes the caller and, with no service, no access.
+
+    With ``TA_AUTH_SERVICE`` unset the authenticator reports
+    ``SERVICE_NOT_PRESENT`` and the user has no target access - the expected
+    shape for an empty, service-less installation.
+    """
+    response = authenticated_client.get("/api/user/")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["user"] == "tester"
+    assert body["target_access"] == []
+    assert body["ping"] == "SERVICE_NOT_PRESENT"
+    assert body["authenticator"]["kind"] == "SERVICE_NOT_PRESENT"
+
+
+@pytest.mark.django_db
+def test_user_roles_requires_authentication(api_client):
+    """``/api/user_roles/`` is authentication-gated."""
+    response = api_client.get("/api/user_roles/")
+
+    assert response.status_code in (401, 403)
+
+
+def test_user_roles_lists_seeded_roles_for_authenticated_user(authenticated_client):
+    """The role list is data-independent: the migration-seeded 'Loader' role is
+    present even on an empty installation, and holds no users."""
+    response = authenticated_client.get("/api/user_roles/")
+
+    assert response.status_code == 200
+    roles = {row["name"]: row for row in _results(response)}
+    assert "Loader" in roles
+    assert roles["Loader"]["user_count"] == 0

--- a/viewer/tests/test_restricted_tas_users.py
+++ b/viewer/tests/test_restricted_tas_users.py
@@ -1,0 +1,112 @@
+"""Tests for the ``RESTRICTED_TAS_USERS`` proposal-membership simulation.
+
+In a real deployment a user's accessible proposals ("Target Access Strings",
+e.g. ``lb12345-1``) come from Keycloak plus the target-access authoriser. For
+non-production deployments the ``RESTRICTED_TAS_USERS`` environment variable
+provides a debug seam that arbitrarily grants a named user a proposal, letting
+tests stand in for that whole chain (see ``api.security`` and the
+``set_restricted_tas_users`` fixture in ``conftest``).
+
+These tests verify the seam itself, how it feeds the security layer, and that
+it surfaces end-to-end through a real access-controlled endpoint - all without
+needing a single ``Target`` in the database.
+"""
+
+from api.security import ISPyBSafeQuerySet, get_restricted_tas_user_proposal
+
+
+def test_restricted_tas_user_matches(make_user, set_restricted_tas_users):
+    """A user named in RESTRICTED_TAS_USERS is granted the paired proposal."""
+    user = make_user("user-a")
+    set_restricted_tas_users("user-a:lb12345-1")
+
+    assert get_restricted_tas_user_proposal(user) == {"lb12345-1"}
+
+
+def test_restricted_tas_user_no_match(make_user, set_restricted_tas_users):
+    """A user absent from RESTRICTED_TAS_USERS is granted nothing."""
+    user = make_user("user-b")
+    set_restricted_tas_users("user-a:lb12345-1")
+
+    assert get_restricted_tas_user_proposal(user) == set()
+
+
+def test_restricted_tas_user_multiple_entries(make_user, set_restricted_tas_users):
+    """Only the entries for the requested user are collected, and they accrue."""
+    user = make_user("user-a")
+    set_restricted_tas_users("user-a:lb12345-1,user-b:lb99999-1,user-a:lb55555-1")
+
+    assert get_restricted_tas_user_proposal(user) == {"lb12345-1", "lb55555-1"}
+
+
+def test_restricted_tas_user_empty_setting(make_user, set_restricted_tas_users):
+    """An unset variable grants nothing (and must not raise)."""
+    user = make_user("user-a")
+    set_restricted_tas_users("")
+
+    assert get_restricted_tas_user_proposal(user) == set()
+
+
+def test_restricted_tas_users_ignored_in_production(
+    make_user, settings, set_restricted_tas_users
+):
+    """The debug seam is inert in production, regardless of the variable."""
+    settings.DEPLOYMENT_MODE = "PRODUCTION"
+    user = make_user("user-a")
+    set_restricted_tas_users("user-a:lb12345-1")
+
+    assert get_restricted_tas_user_proposal(user) == set()
+
+
+def test_restricted_tas_feeds_proposals_for_user(
+    make_user, settings, set_restricted_tas_users
+):
+    """The granted proposal reaches get_proposals_for_user (the security layer)."""
+    settings.TA_AUTH_SERVICE = ""
+    user = make_user("user-a")
+    set_restricted_tas_users("user-a:lb12345-1")
+
+    safe_qs = ISPyBSafeQuerySet()
+    proposals = safe_qs.get_proposals_for_user(user, restrict_public_to_membership=True)
+
+    assert proposals == ["lb12345-1"]
+
+
+def test_restricted_tas_user_sees_only_granted_proposal(
+    api_client, make_user, make_project, settings, set_restricted_tas_users
+):
+    """End-to-end: the granted user sees their proposal's Project and no other.
+
+    ``/api/projects/`` is access-controlled by ISPyBSafeQuerySet, so this proves
+    the simulated membership flows all the way through a real request - with no
+    Target involved.
+    """
+    settings.TA_AUTH_SERVICE = ""
+    make_project("lb12345-1")  # the granted proposal (no Target attached)
+    make_project("lb99999-1")  # an unrelated proposal
+    set_restricted_tas_users("user-a:lb12345-1")
+
+    user_a = make_user("user-a")
+    api_client.force_authenticate(user=user_a)
+    response = api_client.get("/api/projects/")
+
+    assert response.status_code == 200
+    # The Project model's 'title' is exposed as 'target_access_string'.
+    proposals = {row["target_access_string"] for row in response.data["results"]}
+    assert proposals == {"lb12345-1"}
+
+
+def test_user_without_grant_sees_no_proposals(
+    api_client, make_user, make_project, settings, set_restricted_tas_users
+):
+    """A different user, not named in the variable, sees no (non-public) proposal."""
+    settings.TA_AUTH_SERVICE = ""
+    make_project("lb12345-1")
+    set_restricted_tas_users("user-a:lb12345-1")
+
+    user_b = make_user("user-b")
+    api_client.force_authenticate(user=user_b)
+    response = api_client.get("/api/projects/")
+
+    assert response.status_code == 200
+    assert response.data["results"] == []


### PR DESCRIPTION
Closes #953.

## What

Adds a broad set of unit tests verifying the REST API's behaviour on an
**empty installation** — a database with no `viewer.Target` records (and so
none of the experiment / site-observation / pose data that hangs off one).
The aim is breadth, not depth: confirm the API as a whole behaves sanely with
nothing loaded, deferring deep, data-driven assertions to the fixtures that
load a real target archive.

### `viewer/tests/test_empty_api.py`
- A representative slice of access-controlled (`ISPyBSafeQuerySet`) list
  endpoints all answer `200` with an empty, paginated page — for both
  authenticated and anonymous callers.
- Retrieve of a missing record is `404` (not a server error).
- Read-only viewsets reject `POST` (`405`).
- `/api/user/` reports the caller and, with `TA_AUTH_SERVICE` unset,
  `SERVICE_NOT_PRESENT` / no target access.
- `/api/user_roles/` is authentication-gated and lists the migration-seeded
  `Loader` role.

### `viewer/tests/test_restricted_tas_users.py`
Exercises the `RESTRICTED_TAS_USERS` debug seam the ticket calls out for
**simulating a user's proposal membership** (a `user:tas` pairing such as
`user-a:lb12345-1`):
- the `get_restricted_tas_user_proposal` helper (match, no-match, multiple
  entries, empty, and inert-in-production);
- its feed into `get_proposals_for_user` (the security layer);
- end-to-end through `/api/projects/`, proving simulated membership filters a
  real access-controlled request — with no `Target` involved.

### `viewer/tests/conftest.py`
- New `set_restricted_tas_users` fixture, mirroring how the application
  derives both `RESTRICTED_TAS_USERS` settings from the single env var.

## Testing
- `./run-unit-tests.sh` — full suite green (100 passed, 1 skipped); the 45 new
  cases pass.
- `pre-commit run` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)