### PR TITLE
chore: add create-backend-issue and release-staging Claude skills

### DIFF
--- a/.claude/skills/create-backend-issue/SKILL.md
+++ b/.claude/skills/create-backend-issue/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: create-backend-issue
+description: Copy a project-board issue into the fragalysis-backend repo. Use when the user asks to create a backend issue from a project-board issue, e.g. "Create an issue for project issue 1234".
+---
+
+Copy an issue from the **m2ms project board**
+(`https://github.com/orgs/m2ms/projects/2`) into this project's repository
+(`xchem/fragalysis-backend`).
+
+## When to use
+
+Trigger phrases such as:
+
+- "Create an issue for project issue 1234"
+- "Make a backend issue from board issue 1234"
+
+The number the user gives is the **project-board issue number**.
+
+## What it does
+
+Given a project-board issue number, the skill:
+
+1. Reads the source issue from `m2ms/fragalysis-frontend` (the board's planning
+   issues live there).
+2. Verifies the issue carries the **`fragalysis-backend`** label. If it does
+   not, it stops and reports — nothing is created.
+3. Creates a new issue in `xchem/fragalysis-backend` with the **same title**
+   and a **copy of the body** (plus a footer linking back to the source).
+4. Adds a comment on the source issue with a link to the new backend issue.
+
+It is **idempotent**: a hidden marker is written into the comment, so running
+it twice for the same issue refuses to create a duplicate.
+
+## How to run it
+
+Run the helper script with the project-board issue number:
+
+```bash
+.claude/skills/create-backend-issue/create-backend-issue.sh <project-issue-number>
+```
+
+For example, for "Create an issue for project issue 1234":
+
+```bash
+.claude/skills/create-backend-issue/create-backend-issue.sh 1234
+```
+
+On success it prints the source URL and the new backend issue URL — relay both
+to the user. On any error it exits non-zero and prints the reason to stderr;
+report that reason rather than retrying blindly.
+
+## Notes and assumptions
+
+- Requires the `gh` CLI (authenticated, with `repo` scope) and `jq`. No GitHub
+  *project* scope is needed because the issue is resolved by repository, not by
+  querying the board API.
+- The source repo is fixed to `m2ms/fragalysis-frontend`. This is safe because
+  the `fragalysis-backend` label only exists in that repo, so any board issue
+  carrying it lives there. If the board's planning issues ever move to another
+  repo, update `SOURCE_REPO` in `create-backend-issue.sh`.
+- The script never deletes or edits anything; it only creates one issue and one
+  comment. If the label is missing, the issue cannot be read, or it was already
+  imported, it aborts without side effects.

--- a/.claude/skills/create-backend-issue/create-backend-issue.sh
+++ b/.claude/skills/create-backend-issue/create-backend-issue.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Copy a project-board planning issue into the fragalysis-backend repository.
+#
+# Given a project-board issue number, this:
+#   1. reads the issue from the source repo (where the board's planning
+#      issues live),
+#   2. verifies it carries the "fragalysis-backend" label,
+#   3. creates a copy (same title, same body) in the backend repo,
+#   4. comments on the source issue with a link to the new backend issue.
+#
+# It is idempotent: a hidden marker is written into the comment so a second
+# run for the same issue refuses to create a duplicate.
+#
+# Usage: create-backend-issue.sh <project-issue-number>
+
+set -euo pipefail
+
+# --- Configuration ----------------------------------------------------------
+# The board (https://github.com/orgs/m2ms/projects/2) aggregates planning
+# issues that live in SOURCE_REPO. The "fragalysis-backend" label only exists
+# in that repo, so an issue carrying it must live there.
+readonly SOURCE_REPO="m2ms/fragalysis-frontend"
+readonly DEST_REPO="xchem/fragalysis-backend"
+readonly REQUIRED_LABEL="fragalysis-backend"
+# Hidden HTML marker used to detect an issue that has already been imported.
+readonly MARKER="<!-- fragalysis-backend-import -->"
+
+# --- Argument validation ----------------------------------------------------
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $(basename "$0") <project-issue-number>" >&2
+  exit 2
+fi
+
+issue_number="$1"
+if ! [[ "${issue_number}" =~ ^[0-9]+$ ]]; then
+  echo "Error: issue number must be a positive integer (got '${issue_number}')." >&2
+  exit 2
+fi
+
+# --- Dependencies -----------------------------------------------------------
+for cmd in gh jq; do
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    echo "Error: required command '${cmd}' is not installed." >&2
+    exit 3
+  fi
+done
+
+# --- Read the source issue --------------------------------------------------
+echo "Reading ${SOURCE_REPO}#${issue_number} ..." >&2
+if ! issue_json="$(gh issue view "${issue_number}" --repo "${SOURCE_REPO}" \
+    --json number,title,body,labels,url,comments 2>/dev/null)"; then
+  echo "Error: could not read issue ${SOURCE_REPO}#${issue_number}." \
+       "Does it exist, and do you have access?" >&2
+  exit 1
+fi
+
+title="$(jq -r '.title' <<<"${issue_json}")"
+body="$(jq -r '.body' <<<"${issue_json}")"
+source_url="$(jq -r '.url' <<<"${issue_json}")"
+has_label="$(jq -r --arg l "${REQUIRED_LABEL}" \
+  '[.labels[].name] | index($l) != null' <<<"${issue_json}")"
+
+# --- Verify the required label ----------------------------------------------
+if [ "${has_label}" != "true" ]; then
+  echo "Error: ${SOURCE_REPO}#${issue_number} does not have the" \
+       "'${REQUIRED_LABEL}' label; nothing to copy. Aborting." >&2
+  exit 1
+fi
+
+# --- Refuse to create a duplicate -------------------------------------------
+already_imported="$(jq -r --arg m "${MARKER}" \
+  '[.comments[]? | select(.body | contains($m))] | length' <<<"${issue_json}")"
+if [ "${already_imported}" -gt 0 ]; then
+  echo "Error: ${SOURCE_REPO}#${issue_number} has already been imported" \
+       "(import marker found in its comments). Aborting to avoid a duplicate." >&2
+  exit 1
+fi
+
+# --- Build the new issue body -----------------------------------------------
+# The body is a faithful copy of the source, with a footer that records the
+# origin (and gives GitHub a back-link to the source issue).
+body_file="$(mktemp)"
+trap 'rm -f "${body_file}"' EXIT
+{
+  printf '%s\n' "${body}"
+  printf '\n\n---\n'
+  printf '_Imported from the project board — source issue: %s_\n' "${source_url}"
+} >"${body_file}"
+
+# --- Create the backend issue -----------------------------------------------
+echo "Creating issue in ${DEST_REPO} ..." >&2
+new_url="$(gh issue create --repo "${DEST_REPO}" \
+  --title "${title}" --body-file "${body_file}")"
+
+if [ -z "${new_url}" ]; then
+  echo "Error: 'gh issue create' did not return a URL; the backend issue may" \
+       "not have been created. Not commenting on the source issue." >&2
+  exit 1
+fi
+
+# --- Comment on the source issue --------------------------------------------
+comment_body="$(printf '%s\nBackend issue created from this ticket: %s' \
+  "${MARKER}" "${new_url}")"
+echo "Commenting on ${SOURCE_REPO}#${issue_number} ..." >&2
+gh issue comment "${issue_number}" --repo "${SOURCE_REPO}" --body "${comment_body}"
+
+# --- Report -----------------------------------------------------------------
+echo "Done."
+echo "  Source: ${source_url}"
+echo "  Backend issue: ${new_url}"

--- a/.claude/skills/release-staging/SKILL.md
+++ b/.claude/skills/release-staging/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: release-staging
+description: Release the staging branch to production. Opens a staging→production PR, waits for CI, merges it (keeping staging), then publishes a YYYY.MM.ITERATION GitHub release of production. Use when the user asks to "release staging", "do a release", or "release the staging branch".
+---
+
+Promote everything currently on **`staging`** to **`production`** and publish a
+tagged GitHub release for `xchem/fragalysis-backend`.
+
+This is an outward-facing, hard-to-reverse workflow: it merges to a protected
+branch and publishes a public release that triggers the production image build.
+Run the steps in order, **stop and report on any failure** (never swallow an
+error), and pause for confirmation at the two checkpoints called out below.
+
+## Key facts about this repo
+
+- Remote/repo: `xchem/fragalysis-backend`.
+- Release direction: PR with **`--base production --head staging`**.
+- `production` is only ever updated *from* `staging`, so the PR normally has no
+  conflicts. Conflicts only appear if someone committed directly to `production`
+  (e.g. a hotfix). Handle them, don't assume they won't happen.
+- **`staging` is a protected branch and must never be deleted.** Never pass
+  `--delete-branch` to `gh pr merge`; never `git push --delete origin staging`.
+- CI triggers (see `.github/workflows/`):
+  - `build-staging.yaml` runs on every commit to `staging` — these are the
+    checks that appear on the PR's head commit and are what you wait on.
+  - `build-production.yaml` runs on **pushing a `YYYY.MM.N` tag**. It does *not*
+    run on the merge to `production`. **Publishing the release (which creates the
+    tag) is what starts the production build** — so the production build happens
+    *after* the release, not before it.
+- Tag scheme: `YYYY.MM.ITERATION`, ITERATION restarting at 1 each calendar month
+  (latest example: `2026.06.1`). Use the helper script to compute it — don't do
+  the arithmetic by hand.
+
+## Steps
+
+### 1. Get the Release title
+
+Ask the user: **"What is the Release title for this release?"** Wait for their
+answer. This exact string is used both as the PR title and the release title.
+Do not invent one.
+
+### 2. Pre-flight
+
+```bash
+git fetch origin staging production
+```
+
+Confirm there is actually something to release:
+
+```bash
+gh api repos/xchem/fragalysis-backend/compare/production...staging \
+  --jq '{ahead: .ahead_by, behind: .behind_by, commits: [.commits[].commit.message]}'
+```
+
+If `ahead` is 0, there is nothing to release — stop and tell the user.
+
+### 3. Create (or reuse) the PR
+
+If an open `staging`→`production` PR already exists, reuse it; otherwise create
+one with the title from step 1:
+
+```bash
+gh pr create --repo xchem/fragalysis-backend \
+  --base production --head staging \
+  --title "<Release title>" \
+  --body "Release of staging to production."
+```
+
+Capture the PR number for the remaining steps. (To find an existing one:
+`gh pr list --repo xchem/fragalysis-backend --base production --head staging --state open`.)
+
+### 4. Resolve conflicts (only if any)
+
+Check mergeability:
+
+```bash
+gh pr view <num> --repo xchem/fragalysis-backend --json mergeable,mergeStateStatus
+```
+
+If `mergeable` is `CONFLICTING`, resolve by bringing `production` into `staging`
+(staging is the source of truth) — note `staging` is protected, so you may not be
+able to push to it directly; if the push is rejected, **stop and ask the user how
+they want conflicts resolved** rather than forcing anything. Re-check
+mergeability before continuing.
+
+### 5. Approval — normally not needed
+
+`production` branch protection is configured with
+`required_approving_review_count = 0`, so **no review approval is required** to
+merge; do not try to approve the PR (GitHub forbids approving your *own* PR
+anyway, so it would just error). Skip straight to waiting for CI.
+
+Only if a merge is later blocked by a required-review rule (i.e. someone has
+re-enabled required approvals) should you stop and ask the user to have a
+*colleague* approve the PR — the author cannot self-approve. Confirm the current
+rule with:
+
+```bash
+gh api repos/xchem/fragalysis-backend/branches/production/protection \
+  --jq '.required_pull_request_reviews.required_approving_review_count'
+```
+
+### 6. Wait for a successful CI build
+
+Watch the checks on the PR head and block until they finish:
+
+```bash
+gh pr checks <num> --repo xchem/fragalysis-backend --watch --fail-fast
+```
+
+If any check fails, **stop** and report which one — do not merge a red build.
+
+### 7. Checkpoint, then merge (keep staging)
+
+Once CI is green, summarise for the user (PR number/URL, that checks passed) and
+**confirm before merging**. Then:
+
+```bash
+gh pr merge <num> --repo xchem/fragalysis-backend --merge
+```
+
+Use `--merge` (a real merge commit). **Never** add `--delete-branch` — `staging`
+is protected and must survive. Afterwards verify it still exists:
+
+```bash
+git ls-remote --heads origin staging
+```
+
+### 8. Compute the release tag
+
+```bash
+.claude/skills/release-staging/next-release-tag.sh
+```
+
+It prints `NEXT_TAG=YYYY.MM.N` (the tag to create) and `PRIOR_TAG=...` (the
+previous full release, used as the start point for the notes). It ignores
+pre-release (`-rc.N`) tags.
+
+### 9. Checkpoint, then publish the release
+
+Show the user the computed `NEXT_TAG`, the title, and `PRIOR_TAG`, and **confirm
+before publishing** (this is public and triggers the production build). Then:
+
+```bash
+gh release create <NEXT_TAG> --repo xchem/fragalysis-backend \
+  --target production \
+  --title "<Release title>" \
+  --notes-start-tag <PRIOR_TAG> \
+  --generate-notes
+```
+
+- `--target production` tags the current tip of `production` (the merge from
+  step 7).
+- `--generate-notes` with `--notes-start-tag <PRIOR_TAG>` makes the release notes
+  contain **all changes since the prior release** (the merged PRs / commits
+  between `PRIOR_TAG` and this tag) — exactly what's wanted. If `PRIOR_TAG` is
+  empty (no previous release), omit `--notes-start-tag`.
+
+### 10. Report
+
+Tell the user, with links:
+
+- the PR (and that it was merged, `staging` preserved),
+- the new release URL and its tag,
+- that pushing the tag has now started the `build production` CI, and they can
+  watch it with
+  `gh run list --repo xchem/fragalysis-backend --workflow "build production"`.
+
+## Requirements
+
+- `gh` CLI, authenticated with `repo` scope (and permission to merge to
+  `production` / publish releases).
+- `git`, `bash`, and the `gh`-bundled `jq` query engine (`--jq`).

--- a/.claude/skills/release-staging/next-release-tag.sh
+++ b/.claude/skills/release-staging/next-release-tag.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Compute the next production release tag and the prior full-release tag.
+#
+# Prints exactly two lines to stdout, e.g.:
+#   NEXT_TAG=2026.06.2
+#   PRIOR_TAG=2026.06.1
+#
+# Tag scheme is YYYY.MM.ITERATION where ITERATION restarts at 1 each calendar
+# month (UTC). NEXT_TAG is one greater than the highest full-release iteration
+# already used this month, or .1 if this is the month's first release.
+# PRIOR_TAG is the most recent full (non-prerelease) GitHub release, used as the
+# starting point for auto-generated release notes. It is empty if none exist.
+#
+# Pre-release tags (e.g. "2026.06.1-rc.1") are ignored for both calculations.
+
+set -euo pipefail
+
+REPO="xchem/fragalysis-backend"
+
+# Year.month in UTC, e.g. "2026.06". Dots are escaped for the regex below.
+ym=$(date -u +%Y.%m)
+ym_re="^${ym//./\\.}\.([0-9]+)$"
+
+prior_tag=""
+max_iter=0
+
+# gh lists releases newest-first, so the first non-prerelease is the prior one.
+while IFS= read -r tag; do
+  if [ -z "${tag}" ]; then
+    continue
+  fi
+  if [ -z "${prior_tag}" ]; then
+    prior_tag="${tag}"
+  fi
+  if [[ "${tag}" =~ ${ym_re} ]]; then
+    iter="${BASH_REMATCH[1]}"
+    if [ "${iter}" -gt "${max_iter}" ]; then
+      max_iter="${iter}"
+    fi
+  fi
+done < <(gh release list --repo "${REPO}" --limit 200 \
+           --json tagName,isPrerelease \
+           --jq '.[] | select(.isPrerelease == false) | .tagName')
+
+next_iter=$((max_iter + 1))
+
+echo "NEXT_TAG=${ym}.${next_iter}"
+echo "PRIOR_TAG=${prior_tag}"


### PR DESCRIPTION
## Summary

Adds two Claude Code skills under `.claude/skills/`:

- **create-backend-issue** — copies an issue from the m2ms project board into the `xchem/fragalysis-backend` repo.
- **release-staging** — opens a `staging`→`production` PR, waits for CI, merges it (keeping staging), then publishes a `YYYY.MM.ITERATION` GitHub release.

These are tooling-only additions; no application code is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)