### PR TITLE
fix(958): base64-encode binary map data in /api/protmap/

### DIFF
--- a/viewer/serializers.py
+++ b/viewer/serializers.py
@@ -1,3 +1,4 @@
+import base64
 import logging
 import math
 from pathlib import Path
@@ -462,11 +463,15 @@ class ProtMapInfoSerializer(serializers.ModelSerializer):
     map_data = serializers.SerializerMethodField()
 
     def get_map_data(self, obj):
-        # TODO: this was formerly protein.map_info. based on
-        # description in the spec, it seems this is equivalent to
-        # event_file in site_observation, but it's binary and not read
+        # event_file (formerly protein.map_info) holds a *binary* electron-
+        # density map, so it cannot be decoded as UTF-8 text: doing so raised
+        # UnicodeDecodeError on the first non-UTF-8 byte and surfaced as a 500
+        # on /api/protmap/ (ticket #958). Return its bytes base64-encoded so the
+        # JSON response is valid and lossless; clients base64-decode to recover
+        # the raw map.
         if obj.event_file:
-            return open(obj.event_file.path, encoding='utf-8').read()
+            with open(obj.event_file.path, "rb") as map_file:
+                return base64.b64encode(map_file.read()).decode("ascii")
         else:
             return None
 

--- a/viewer/tests/test_protmap_serialization.py
+++ b/viewer/tests/test_protmap_serialization.py
@@ -1,0 +1,50 @@
+"""Regression test for ticket #958.
+
+``SiteObservation.event_file`` holds a *binary* electron-density map. The
+``ProtMapInfoSerializer`` formerly read it with
+``open(..., encoding='utf-8').read()``, which raised ``UnicodeDecodeError`` on
+the first non-UTF-8 byte (``0x9c`` in the reported traceback) and surfaced as a
+500 on ``/api/protmap/``.
+
+The serializer now returns the file's bytes base64-encoded, so the JSON
+response is valid and lossless regardless of the file's contents.
+"""
+import base64
+from pathlib import Path
+
+from viewer.models import SiteObservation
+from viewer.serializers import ProtMapInfoSerializer
+
+# A map file is binary; this deliberately includes 0x9c (the byte from the
+# ticket's traceback) which is not a valid UTF-8 start byte.
+BINARY_MAP_CONTENT = b"MAP \x00\x9c\xff\xfe binary electron-density data"
+
+
+def _write_event_file(media_root: str, content: bytes) -> str:
+    """Write ``content`` under MEDIA_ROOT and return the storage-relative name."""
+    name = "target_loader_data/test_958_event.map"
+    target = Path(media_root) / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+    return name
+
+
+def test_get_map_data_base64_encodes_binary_event_file(settings):
+    """A binary event_file is returned base64-encoded, not decoded as text."""
+    name = _write_event_file(settings.MEDIA_ROOT, BINARY_MAP_CONTENT)
+    obs = SiteObservation(event_file=name)
+
+    result = ProtMapInfoSerializer().get_map_data(obs)
+
+    # It is valid base64 that round-trips back to the original bytes ...
+    assert result == base64.b64encode(BINARY_MAP_CONTENT).decode("ascii")
+    assert base64.b64decode(result) == BINARY_MAP_CONTENT
+    # ... and crucially it is a str (JSON-renderable), never raising.
+    assert isinstance(result, str)
+
+
+def test_get_map_data_returns_none_when_no_event_file():
+    """No event_file yields None rather than an error."""
+    obs = SiteObservation(event_file="")
+
+    assert ProtMapInfoSerializer().get_map_data(obs) is None


### PR DESCRIPTION
Fixes #958.

## Problem

`/api/protmap/` returns 500 in production. `SiteObservation.event_file` is a **binary** electron-density map, but `ProtMapInfoSerializer.get_map_data` read it as UTF-8 text:

```python
return open(obj.event_file.path, encoding='utf-8').read()
```

On real map data this raises `UnicodeDecodeError` on the first non-UTF-8 byte (the production traceback failed on `0x9c`). The field was historically a text `map_info`; when it became the binary `event_file` the text read was never updated (an in-code `TODO` already flagged "it's binary and not read").

## Fix

Read the file as bytes and return it **base64-encoded**, so the JSON response is valid and lossless; clients base64-decode to recover the raw map. Also switched to a context manager so the file handle is always closed.

```python
if obj.event_file:
    with open(obj.event_file.path, "rb") as map_file:
        return base64.b64encode(map_file.read()).decode("ascii")
else:
    return None
```

## ⚠️ API contract change (frontend note)

`map_data` now contains **base64**, not raw text. This is unavoidable for binary content in a JSON field — and the endpoint currently *always* 500s on real maps, so there is no working behaviour to preserve. Any consumer of `/api/protmap/` must base64-decode `map_data`. The sibling text endpoints (`/api/protpdb/`, `/api/protpdbbound/`) are unchanged — PDB files are ASCII text and read fine.

## Testing

New regression test `viewer/tests/test_protmap_serialization.py` (written first, TDD):
- confirms binary content including `0x9c` is base64-encoded and round-trips (it reproduced the exact production `UnicodeDecodeError` before the fix);
- confirms the no-`event_file` case still returns `None`.

Full suite: **102 passed, 1 skipped**; pre-commit (isort/black/mypy/pylint) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
