### PR TITLE
feat(issue): move the project-board card as the issue progresses

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue
-description: Work on a GitHub issue end-to-end in a git worktree — read the issue, explore the code, branch from staging, write the test first (TDD), commit, and open a PR. Use when the user says e.g. "work on issue 958", "start issue 1234", "/issue N", or asks to take a fragalysis-backend issue from triage to PR.
+description: Work on a GitHub issue end-to-end in a git worktree — read the issue, move its board card to In Progress, explore the code, branch from staging, write the test first (TDD), commit, and open a PR. Use when the user says e.g. "work on issue 958", "start issue 1234", "/issue N", or asks to take a fragalysis-backend issue from triage to PR.
 ---
 
 # Issue Workflow
@@ -24,13 +24,31 @@ blockers or dependencies. Follow links to source/board issues if the body has
 them (backend issues imported by `create-backend-issue` carry a footer linking
 to their `m2ms/fragalysis-frontend` source).
 
-### 2. Explore the codebase
+### 2. Move the board card to "In Progress"
+
+The m2ms project board (`https://github.com/orgs/m2ms/projects/2`) tracks the
+*frontend* source issue, not this backend issue. Move its card from its backlog
+lane into the matching "In Progress" lane — e.g. `Infra - Backlog` →
+`Infra - In Progress`:
+
+```bash
+.claude/skills/issue/move-board-card.sh <number> --in-progress
+```
+
+The script follows the backend issue's "source issue" footer to the board card,
+derives the lane's category (the text before the first ` - `), and moves the card
+to `{Category} - In Progress`. Cards **already in an "In Progress" lane are left
+untouched.** If there is no matching "In Progress" lane — or no board card can be
+found — it changes nothing and prints why; **relay that to the user**. Requires a
+`gh` token with the `project` (write) scope.
+
+### 3. Explore the codebase
 
 Before coding: search for the related code, understand the current
 implementation, and identify the files that need changing. Read
 `ARCHITECTURE.md` first if the change touches models, security, or the loader.
 
-### 3. Create a worktree
+### 4. Create a worktree
 
 We always branch from **`staging`** (the default branch). The branch name is the
 committer's initials, the issue number, and a brief description:
@@ -56,7 +74,7 @@ cd "../${branch}"
 > `poetry env info --path` (run from the main checkout) and invoke that
 > `…/bin/pytest` directly from inside the worktree.
 
-### 4. Implement the changes (TDD)
+### 5. Implement the changes (TDD)
 
 - **Write the test first**, watch it fail (red), then make it pass (green). See
   `viewer/tests/` for the fixture style (`conftest.py`), and existing regression
@@ -74,12 +92,12 @@ cd "../${branch}"
   with the trailer:
   `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
 
-### 5. Update the issue
+### 6. Update the issue
 
 As you work, comment on the issue with progress and any blockers/questions, and
 note the PR once it exists.
 
-### 6. Create the PR and link it
+### 7. Create the PR and link it
 
 ```bash
 gh pr create --repo xchem/fragalysis-backend --base staging \
@@ -95,7 +113,16 @@ gh pr create --repo xchem/fragalysis-backend --base staging \
   `--body "$(cat <<EOF …)"` lets the shell evaluate backticks/`$()` in the body
   and mangles it — a file avoids that.
 
-### 7. If you find an unrelated bug
+Once the PR is open, move the board card into the review lane:
+
+```bash
+.claude/skills/issue/move-board-card.sh <number> "Dev Done - Do review (DEV)"
+```
+
+If that lane can't be found or no board card exists, the script changes nothing
+and says why — **relay that to the user**.
+
+### 8. If you find an unrelated bug
 
 1. Create a new issue with the details (`create-backend-issue` if it originates
    on the board).

--- a/.claude/skills/issue/move-board-card.sh
+++ b/.claude/skills/issue/move-board-card.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# Move the project-board card for a backend issue to a target swimlane.
+#
+# The m2ms project board (https://github.com/orgs/m2ms/projects/2) tracks the
+# *frontend* planning issues (m2ms/fragalysis-frontend), not the backend issues
+# this skill works on. A backend issue created by `create-backend-issue` carries
+# a footer linking to its source frontend issue; we follow that link to find the
+# board card.
+#
+# Target (second argument) is one of:
+#   --in-progress   Move to "{Category} - In Progress", where Category is the
+#                   text before the first " - " in the card's current lane
+#                   (e.g. "Infra - Backlog" -> "Infra - In Progress"). Cards that
+#                   are *already* in an "In Progress" lane are left untouched.
+#   <lane name>     Move to that exact lane, matched case-insensitively
+#                   (e.g. "Dev Done - Do review (DEV)").
+#
+# If the target lane does not exist, no board card can be found, or the card is
+# already in the target lane, nothing is moved and the reason is printed; none of
+# those are fatal to the issue workflow, so they exit 0.
+#
+# Usage: move-board-card.sh <backend-issue-number> (--in-progress | <lane name>)
+
+set -euo pipefail
+
+# --- Configuration ----------------------------------------------------------
+readonly PROJECT_NUMBER="2"
+readonly FRONTEND_OWNER="m2ms"
+readonly FRONTEND_REPO="fragalysis-frontend"
+readonly BACKEND_REPO="xchem/fragalysis-backend"
+readonly STATUS_FIELD_NAME="Status"
+# Suffix appended to a category for the --in-progress target, matched
+# case-insensitively (the board mixes "In Progress" and "In progress").
+readonly IN_PROGRESS_SUFFIX="In Progress"
+
+# Lowercase helper (the host's bash is 3.2, which lacks ${var,,}).
+lc() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# --- Argument validation ----------------------------------------------------
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $(basename "$0") <backend-issue-number> (--in-progress | <lane name>)" >&2
+  exit 2
+fi
+
+backend_number="$1"
+target_arg="$2"
+if ! [[ "${backend_number}" =~ ^[0-9]+$ ]]; then
+  echo "Error: issue number must be a positive integer (got '${backend_number}')." >&2
+  exit 2
+fi
+if [ -z "${target_arg}" ]; then
+  echo "Error: target lane (or --in-progress) must not be empty." >&2
+  exit 2
+fi
+
+# --- Dependencies -----------------------------------------------------------
+for cmd in gh jq; do
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    echo "Error: required command '${cmd}' is not installed." >&2
+    exit 3
+  fi
+done
+
+# --- Find the source (board) issue ------------------------------------------
+# The board card lives on the frontend issue linked from the backend issue body.
+if ! body="$(gh issue view "${backend_number}" --repo "${BACKEND_REPO}" \
+    --json body -q '.body' 2>/dev/null)"; then
+  echo "Error: could not read ${BACKEND_REPO}#${backend_number}." >&2
+  exit 1
+fi
+
+frontend_number="$(grep -oiE "${FRONTEND_REPO}/issues/[0-9]+" <<<"${body}" \
+  | head -1 | grep -oE '[0-9]+$' || true)"
+
+if [ -z "${frontend_number}" ]; then
+  echo "Couldn't move the board card: ${BACKEND_REPO}#${backend_number} has no" \
+       "link to a ${FRONTEND_OWNER}/${FRONTEND_REPO} source issue, so there is no" \
+       "board card to find."
+  exit 0
+fi
+
+# --- Read the card's current lane and the board's Status options ------------
+item_json="$(gh api graphql -f query='
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $number) {
+        projectItems(first: 20) {
+          nodes {
+            id
+            project {
+              number
+              id
+              field(name: "'"${STATUS_FIELD_NAME}"'") {
+                ... on ProjectV2SingleSelectField {
+                  id
+                  options { id name }
+                }
+              }
+            }
+            fieldValueByName(name: "'"${STATUS_FIELD_NAME}"'") {
+              ... on ProjectV2ItemFieldSingleSelectValue { name }
+            }
+          }
+        }
+      }
+    }
+  }' -f owner="${FRONTEND_OWNER}" -f repo="${FRONTEND_REPO}" \
+     -F number="${frontend_number}")"
+
+# The item on *our* board (project number PROJECT_NUMBER).
+node="$(jq -c --argjson pn "${PROJECT_NUMBER}" \
+  '.data.repository.issue.projectItems.nodes[]? | select(.project.number == $pn)' \
+  <<<"${item_json}" | head -1)"
+
+if [ -z "${node}" ]; then
+  echo "Couldn't move the board card: ${FRONTEND_OWNER}/${FRONTEND_REPO}" \
+       "#${frontend_number} is not on project board #${PROJECT_NUMBER}."
+  exit 0
+fi
+
+item_id="$(jq -r '.id' <<<"${node}")"
+project_id="$(jq -r '.project.id' <<<"${node}")"
+status_field_id="$(jq -r '.project.field.id' <<<"${node}")"
+current_lane="$(jq -r '.fieldValueByName.name // ""' <<<"${node}")"
+
+if [ -z "${current_lane}" ]; then
+  echo "Couldn't move the board card: ${FRONTEND_OWNER}/${FRONTEND_REPO}" \
+       "#${frontend_number} has no Status set on the board."
+  exit 0
+fi
+
+# --- Work out the target lane -----------------------------------------------
+if [ "${target_arg}" = "--in-progress" ]; then
+  # Only move cards that are not already in progress. In-progress lanes are named
+  # "{Category} - In Progress" (or lowercase "In progress"), so treat any lane
+  # whose name ends in "in progress" as already in progress.
+  if [[ "$(lc "${current_lane}")" == *"in progress" ]]; then
+    echo "Board card for #${frontend_number} is already in an 'In Progress' lane" \
+         "('${current_lane}'). Not moving it."
+    exit 0
+  fi
+  # Category = the text before the first " - " (the whole name if there is none).
+  category="${current_lane%% - *}"
+  target_name="${category} - ${IN_PROGRESS_SUFFIX}"
+else
+  target_name="${target_arg}"
+fi
+
+# Already in the target lane? Nothing to do.
+if [ "$(lc "${current_lane}")" = "$(lc "${target_name}")" ]; then
+  echo "Board card for #${frontend_number} is already in '${current_lane}'." \
+       "Nothing to move."
+  exit 0
+fi
+
+# Find the matching option id, comparing names case-insensitively.
+target_option_id="$(jq -r --arg want "$(lc "${target_name}")" \
+  '.project.field.options[] | select((.name | ascii_downcase) == $want) | .id' \
+  <<<"${node}" | head -1)"
+
+if [ -z "${target_option_id}" ]; then
+  echo "Couldn't move the board card: no '${target_name}' lane exists on board" \
+       "#${PROJECT_NUMBER} (current lane '${current_lane}'). Leaving it where it is."
+  exit 0
+fi
+
+# --- Move it ----------------------------------------------------------------
+echo "Moving board card for #${frontend_number} from '${current_lane}' to" \
+     "'${target_name}' ..." >&2
+if ! gh api graphql -f query='
+    mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $project
+        itemId: $item
+        fieldId: $field
+        value: { singleSelectOptionId: $option }
+      }) { projectV2Item { id } }
+    }' \
+    -f project="${project_id}" \
+    -f item="${item_id}" \
+    -f field="${status_field_id}" \
+    -f option="${target_option_id}" >/dev/null; then
+  echo "Error: failed to move the board card. If this is a permissions error," \
+       "your token needs the 'project' (write) scope (gh auth refresh -s project)." >&2
+  exit 1
+fi
+
+echo "Done. Board card for ${FRONTEND_OWNER}/${FRONTEND_REPO}#${frontend_number}" \
+     "moved to '${target_name}'."


### PR DESCRIPTION
## What

Keeps the m2ms project board in step with work done via the `issue` skill, by moving the board card as the issue progresses. Adds `.claude/skills/issue/move-board-card.sh` and two calls in the skill:

- **Step 2** (after reading the issue): `move-board-card.sh <n> --in-progress` → moves the card to its `{Category} - In Progress` lane (e.g. `Infra - Backlog` → `Infra - In Progress`). **Cards already in any "In Progress" lane are left untouched.**
- **Step 7** (after opening the PR): `move-board-card.sh <n> "Dev Done - Do review (DEV)"`.

## How it works

The board tracks the **frontend** source issue (`m2ms/fragalysis-frontend`), not the backend issue. The script follows the backend issue's "source issue" footer (written by `create-backend-issue`) to the frontend issue, reads its board card directly via `issue.projectItems` (no whole-board pagination), resolves the target lane **case-insensitively** (the board mixes "In Progress" / "In progress"), and moves it.

If the target lane doesn't exist, no board card can be found, or the card is already in the target lane, it **changes nothing and prints why** (exit 0) — the skill relays that to the user. Requires a `gh` token with the `project` (write) scope.

## Verification

Validated the source-link resolution and the lane-mapping/guard logic against the live board options (real example: backend #958 → frontend #2191 → `Infra - Backlog`):

| current lane | target | result |
|---|---|---|
| Infra - Backlog | --in-progress | → Infra - In Progress |
| Infra - In Progress | --in-progress | skip (already in progress) |
| Infra - In Progress | Dev Done… | → Dev Done - Do review (DEV) |
| Backlog | Dev Done… | → Dev Done - Do review (DEV) |
| Dev Done… | Dev Done… | no-op |

Syntax/pre-commit clean; **bash-3.2 safe** (no `${var,,}` — the host bash is 3.2). The live board mutation runs only when the skill is actually used. No application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
