### PR TITLE
docs(skills): fix build-stack and harden release-staging

### DIFF
--- a/.claude/skills/build-stack/SKILL.md
+++ b/.claude/skills/build-stack/SKILL.md
@@ -9,18 +9,38 @@ project where we build and push the final application image. We don't build the
 front-end and instead rely on the frontend that is picked up in the stack Dockerfile
 (e.g. xchem/fragalysis-frontend:latest).
 
-Environment variables are used to control the build: -
+Environment variables are used to control the build. **Ask the developer for only
+one value, `STACK_NAMESPACE`** (their DockerHub/GitHub username, e.g.
+"alanbchristie"); derive all the others as described below and `export` them before
+building: -
 
+- STACK_NAMESPACE is the developer's username — **ask for this**
 - BE_NAMESPACE is always "xchem"
-- BE_IMAGE_TAG is set to the current fragalysis-backend branch name (e.g. "m2ms-1234", the GITHUB_REF_SLUG)
-- STACK_NAMESPACE is the developer's GitHub username (e.g. "alanbchristie")
+- BE_IMAGE_TAG is the current fragalysis-backend branch name *slugified*
+  (e.g. "m2ms-1234"). This is the `GITHUB_REF_SLUG` CI uses, so it is lower-cased
+  and has `/` replaced by `-` (e.g. branch `feature/Foo` becomes `feature-foo`).
+  Use the slug, not the raw branch name, so the tag matches any CI-built image.
 - STACK_IMAGE_TAG is the same as BE_IMAGE_TAG
+- FE_NAMESPACE is "xchem" (we don't build the front-end)
+- FE_IMAGE_TAG is "latest" (the front-end image picked up by the stack Dockerfile)
+
+So, once you have `STACK_NAMESPACE` from the developer, set everything up with: -
+
+```
+export STACK_NAMESPACE=<the value the developer gave you>
+
+export BE_NAMESPACE=xchem
+export BE_IMAGE_TAG=$(git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]' | tr '/' '-')
+export STACK_IMAGE_TAG=${BE_IMAGE_TAG}
+export FE_NAMESPACE=xchem
+export FE_IMAGE_TAG=latest
+```
 
 >   If the developer is on staging or production there's no need to build anything,
     as an official image will exist in `xchem/fragalysis-stack` DockerHub registry
     (typically `xchem/fragalysis-stack:latest`)
 
->   If there are no local modifications a built might not be necessary,
+>   If there are no local modifications a build might not be necessary,
     as the CI process (`build-dev.yaml`) ensures that a container image is built for
     the current branch. If you're on branch `m2ms-1234` for example you might find
     the image `xchem/fragalysis-backend:m2ms-1234` already exists.
@@ -28,9 +48,17 @@ Environment variables are used to control the build: -
 To build the fragalysis-backend AMD image: -
 
 ```
-docker buildx build . --platform linux/amd64 \
+docker buildx build . --platform linux/amd64 --load \
   -t ${BE_NAMESPACE}/fragalysis-backend:${BE_IMAGE_TAG}
 ```
+
+>   The `--load` is important. The stack Dockerfile does
+    `FROM ${BE_NAMESPACE}/fragalysis-backend:${BE_IMAGE_TAG}`, so the image must be
+    in the *local* image store. Without `--load` (or `--push`) a `docker-container`
+    or `cloud` builder leaves the image only in its build cache, and the stack build
+    silently pulls the published image from DockerHub instead of your local one -
+    so your local backend changes would be lost. (`--load` works here because this
+    is a single-platform build.)
 
 Once the build has been successful we then move to the fragalysis-stack's project
 directory.
@@ -42,6 +70,13 @@ directory.
 cd ../fragalysis-stack
 ```
 
+The stack image is pushed to the developer's own namespace, so log in first
+(if you are not already): -
+
+```
+docker login
+```
+
 Then we can build and push the fragalysis-stack image: -
 
 ```
@@ -51,3 +86,8 @@ docker buildx build . --platform linux/amd64 \
   --build-arg FE_NAMESPACE=${FE_NAMESPACE} --build-arg FE_IMAGE_TAG=${FE_IMAGE_TAG} \
   --push
 ```
+
+>   `FE_NAMESPACE` and `FE_IMAGE_TAG` must be set (see the environment variables
+    above). If they are unset the `--build-arg` expands to an empty value, which
+    overrides the Dockerfile defaults (`xchem`/`latest`) with an empty string and
+    produces an invalid `FROM /fragalysis-frontend:` reference.

--- a/.claude/skills/release-staging/SKILL.md
+++ b/.claude/skills/release-staging/SKILL.md
@@ -54,6 +54,21 @@ gh api repos/xchem/fragalysis-backend/compare/production...staging \
 
 If `ahead` is 0, there is nothing to release — stop and tell the user.
 
+Then confirm the **latest `build staging` CI run on the `staging` branch was
+successful** — we never release a branch whose own CI is red or still running:
+
+```bash
+gh run list --repo xchem/fragalysis-backend --workflow "build staging" \
+  --branch staging --limit 1 \
+  --json status,conclusion,headSha,url
+```
+
+The latest run must have `status` = `completed` **and** `conclusion` = `success`.
+If it is anything else — `failure`, `cancelled`, still `in_progress`/`queued`, or
+no run at all — **stop and report it; do not proceed**. (Also sanity-check that
+`headSha` matches the current tip of `staging` from the pre-flight fetch; if a
+newer commit has no run yet, wait for it or stop.)
+
 ### 3. Create (or reuse) the PR
 
 If an open `staging`→`production` PR already exists, reuse it; otherwise create
@@ -159,15 +174,36 @@ gh release create <NEXT_TAG> --repo xchem/fragalysis-backend \
   between `PRIOR_TAG` and this tag) — exactly what's wanted. If `PRIOR_TAG` is
   empty (no previous release), omit `--notes-start-tag`.
 
-### 10. Report
+### 10. Wait for the production build
+
+Publishing the release pushed the `YYYY.MM.N` tag, which triggers
+`build-production.yaml`. Wait for that build to finish before ending the skill.
+
+The tag push may take a few seconds to register a run, so find the run for this
+tag (retry briefly if it hasn't appeared yet):
+
+```bash
+gh run list --repo xchem/fragalysis-backend --workflow "build production" \
+  --limit 5 --json databaseId,headBranch,status,conclusion,url
+```
+
+Identify the run whose `headBranch` is the new tag (`<NEXT_TAG>`), then watch it
+to completion (this blocks until it finishes and exits non-zero on failure):
+
+```bash
+gh run watch <databaseId> --repo xchem/fragalysis-backend --exit-status
+```
+
+### 11. Report
 
 Tell the user, with links:
 
 - the PR (and that it was merged, `staging` preserved),
 - the new release URL and its tag,
-- that pushing the tag has now started the `build production` CI, and they can
-  watch it with
-  `gh run list --repo xchem/fragalysis-backend --workflow "build production"`.
+- **the outcome of the production build** — clearly state whether
+  `build production` **succeeded or failed**, with a link to the run
+  (`url` from step 10). If it failed (or was cancelled), say so plainly and point
+  at the failing run; do not present the release as fully done.
 
 ## Requirements
 


### PR DESCRIPTION
Reviewed and corrected two hand-written skills.

## build-stack
- Ask the developer for **only** `STACK_NAMESPACE`; derive `BE_NAMESPACE`, `BE_IMAGE_TAG` (slugified branch), `STACK_IMAGE_TAG`, `FE_NAMESPACE`, `FE_IMAGE_TAG` automatically.
- **Bug:** add `--load` to the backend build so the stack `FROM xchem/fragalysis-backend:<tag>` uses the locally-built image rather than silently pulling the published one (matters for `docker-container`/`cloud` builders).
- **Bug:** define `FE_NAMESPACE`/`FE_IMAGE_TAG` so the `--build-arg`s do not expand to empty and produce an invalid `FROM /fragalysis-frontend:`.
- Clarify `BE_IMAGE_TAG` is the `GITHUB_REF_SLUG` (slugified branch), add a `docker login` step before the push, fix a typo.

## release-staging
- **Do not proceed** unless the latest `build staging` CI run on `staging` is `completed`/`success`.
- After tagging `production`, **wait** for the `build production` run and **report** whether it succeeded or failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
