### PR TITLE
fix(ci): set provenance:false to stop "unknown blob" on docker push

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -127,11 +127,17 @@ jobs:
       with:
         context: .
         tags: ${{ steps.vars.outputs.BE_NAMESPACE }}/fragalysis-backend:${{ env.GITHUB_REF_SLUG }}
+        # Build a plain single-image manifest. With buildx's default provenance
+        # attestation the build produces an OCI index whose attestation blob the
+        # separate 'docker push' step cannot resolve, failing intermittently
+        # with "unknown blob".
+        provenance: false
     - name: Display
       uses: docker/build-push-action@v6
       with:
         context: .
         tags: ${{ steps.vars.outputs.BE_NAMESPACE }}/fragalysis-backend:${{ env.GITHUB_REF_SLUG }}
+        provenance: false
     - name: Vulnerability Scan (OSV)
       # The vulnerability scan (using Google's OSV)
       # Allowed to fail (we force true) as it's used for information only

--- a/.github/workflows/build-production.yaml
+++ b/.github/workflows/build-production.yaml
@@ -173,6 +173,11 @@ jobs:
         tags: |
           ${{ steps.vars.outputs.BE_NAMESPACE }}/fragalysis-backend:${{ steps.vars.outputs.tag }}
           ${{ steps.vars.outputs.BE_NAMESPACE }}/fragalysis-backend:stable
+        # Build a plain single-image manifest. With buildx's default provenance
+        # attestation the build produces an OCI index whose attestation blob the
+        # separate 'docker push' step cannot resolve, failing intermittently
+        # with "unknown blob".
+        provenance: false
     - name: Login to DockerHub
       if: steps.vars.outputs.push == 'true'
       uses: docker/login-action@v3

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -193,6 +193,11 @@ jobs:
       with:
         context: .
         tags: ${{ steps.vars.outputs.BE_NAMESPACE }}/fragalysis-backend:${{ steps.vars.outputs.tag }}
+        # Build a plain single-image manifest. With buildx's default provenance
+        # attestation the build produces an OCI index whose attestation blob the
+        # separate 'docker push' step cannot resolve, failing intermittently
+        # with "unknown blob".
+        provenance: false
     - name: Login to DockerHub
       if: steps.vars.outputs.push == 'true'
       uses: docker/login-action@v3


### PR DESCRIPTION
## Problem

The `Push` step (`docker push`) fails intermittently with **`unknown blob`** —
seen on `build dev` (PR #965 branch) and `build staging` (the #965 merge,
run 26892037418). The layers push, then the final manifest push errors:

```
20bbea0b2472: Pushed
unknown blob
##[error]Process completed with exit code 1.
```

## Cause

`docker/build-push-action@v6` builds with buildx, which now attaches a
**provenance attestation** by default. That turns the built image into an OCI
**image index** with an extra attestation manifest/blob. The workflows build in
one step and then `docker push` in a separate step; the classic `docker push`
cannot resolve the attestation blob in the local image store, so it fails with
`unknown blob`. It is intermittent because it depends on which blobs the
registry already has.

## Fix

Set `provenance: false` on the `build-push-action` build step in all three build
workflows (`build-dev`, `build-staging`, `build-production`). The build then
yields a plain single-image manifest that the separate `docker push` handles
cleanly. No other behaviour changes.

## Verification

- YAML validated; `pre-commit` clean.
- The build-dev run for this branch exercises the patched `Docker build` →
  `Push` path; a green Push (no `unknown blob`) confirms the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
