### PR TITLE
feat(968): verify additional model objects in target-loader integration test

### DIFF
--- a/INTEGRATION-TESTS.md
+++ b/INTEGRATION-TESTS.md
@@ -74,13 +74,33 @@ ALPHA:
     targets: 1
     experiments: 7642
     site_observations: 67
+    canon_sites: null            # other model objects the load produces;
+    canon_site_confs: null       #   null until a real count is filled in
+    xtalform_sites: null
     poses: 62
     target_experiment_uploads: 1
+    objects:                     # optional CONTENT assertions (see below)
+      targets:
+        - title: A71EV2A
 ```
 
-`target_title` and `targets` are always asserted. Each remaining count is only
-asserted when **non-null**, so a new identifier can start with `null`
-placeholders and gain assertions as the real numbers are filled in.
+**Counts.** `target_title` and `targets` are always asserted. Each remaining
+count is only asserted when **non-null**, so a new identifier can start with
+`null` placeholders and gain assertions as the real numbers are filled in. The
+count keys span the model objects a target load produces: `experiments`,
+`site_observations`, `canon_sites`, `canon_site_confs`, `xtalform_sites`,
+`poses` and `target_experiment_uploads`.
+
+**Object content (`expect.objects`).** Beyond bare counts, an optional
+`objects` section content-checks the objects an endpoint returns. Under each
+endpoint name (`targets`, `experiments`, `site_observations`, `canon_sites`,
+`canon_site_confs`, `xtalform_sites`, `poses`) you list one or more
+**field-subsets** — only the fields you name are compared, and the returned
+object may carry many more. The whole *paginated* result set is searched, and
+the test fails naming any expectation it cannot find. This is how a per-identity
+assertion like "the **ALPHA** upload yields a `SiteObservation` with code *X*"
+is expressed; populate it with real values captured from a stack run, exactly
+as the counts are.
 
 ---
 
@@ -99,9 +119,13 @@ running stack owns the one real database. For each manifest upload it:
    `status == "SUCCESS"`. The poll tolerates transient non-200s: while the load
    runs, `task_status` briefly returns **404** ("Proposal not found") because
    the proposal's `Project` is not committed until partway through the load.
-4. **Asserts** the GET endpoints against the manifest `expect`:
-   `/api/targets/`, `/api/experiments/`, `/api/site_observations/`,
-   `/api/poses/`, `/api/target_experiment_uploads/`.
+4. **Asserts** the GET endpoints against the manifest `expect`. First the
+   `count`s — `/api/targets/`, `/api/experiments/`, `/api/site_observations/`,
+   `/api/canon_sites/`, `/api/canon_site_confs/`, `/api/xtalform_sites/`,
+   `/api/poses/`, `/api/target_experiment_uploads/` (each only when its
+   manifest count is non-null) — then any `expect.objects` **content**
+   assertions, paging through each named endpoint's full result set and failing
+   with the unmatched expectations if an expected object is absent.
 
 Visibility for the anonymous GET/poll comes from the stack's `PUBLIC_TAS`, which
 publishes the loaded proposal (the loaded `Project.title` equals the TAS) so the
@@ -241,7 +265,10 @@ identifier are defined once as workflow-level `env` (`UNIT_TEST_BUCKET_AND_PATH`
 3. Capture the real `expect` counts by running the stack once and reading the
    endpoint `count`s back (this is how the `ALPHA` numbers were obtained) — then
    replace the `null`s. A non-null count turns on that endpoint's assertion.
-4. Point CI/local runs at it with `UNIT_TEST_DATA_IDENTIFIER=<IDENTIFIER>`.
+4. (Optional) Add `expect.objects` entries to content-check specific returned
+   objects — e.g. a known `site_observations` code — using real values from the
+   same stack run. Each entry is a field-subset; see *The manifest* above.
+5. Point CI/local runs at it with `UNIT_TEST_DATA_IDENTIFIER=<IDENTIFIER>`.
 
 ---
 

--- a/INTEGRATION-TESTS.md
+++ b/INTEGRATION-TESTS.md
@@ -265,6 +265,10 @@ identifier are defined once as workflow-level `env` (`UNIT_TEST_BUCKET_AND_PATH`
 3. Capture the real `expect` counts by running the stack once and reading the
    endpoint `count`s back (this is how the `ALPHA` numbers were obtained) — then
    replace the `null`s. A non-null count turns on that endpoint's assertion.
+   You don't have to read them by hand: for every endpoint whose manifest count
+   is still `null`, the test emits a **warning** with the observed count (shown
+   in pytest's warnings summary even on a passing run), so one CI run surfaces
+   every number waiting to be pinned down.
 4. (Optional) Add `expect.objects` entries to content-check specific returned
    objects — e.g. a known `site_observations` code — using real values from the
    same stack run. Each entry is a field-subset; see *The manifest* above.

--- a/viewer/tests/external_data.py
+++ b/viewer/tests/external_data.py
@@ -20,7 +20,7 @@ test, mirroring ``requires_archive`` in ``test_target_loader.py``.
 
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 from urllib.parse import urlparse
 
 import pytest
@@ -126,3 +126,31 @@ def load_manifest(endpoint: str) -> Dict[str, Any]:
             f"{DATA_IDENTIFIER_ENV}={identifier!r}"
         )
     return manifest[identifier]
+
+
+def object_matches(row: Dict[str, Any], expected: Dict[str, Any]) -> bool:
+    """True when ``row`` satisfies every field in the ``expected`` subset.
+
+    A returned API object carries far more fields than a manifest wants to pin
+    down, so an expectation is a *subset*: every key in ``expected`` must be
+    present in ``row`` with an equal value, but ``row`` may carry extra fields.
+    An empty ``expected`` matches any row.
+    """
+    return all(key in row and row[key] == value for key, value in expected.items())
+
+
+def missing_objects(
+    results: List[Dict[str, Any]], expected_objects: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """Return the ``expected_objects`` that no row in ``results`` satisfies.
+
+    Each expected object is a field-subset (see :func:`object_matches`). An
+    empty return value means every expectation was found; a non-empty one names
+    exactly which expectations were not, so the caller can fail loudly with the
+    unmatched expectations rather than a bare boolean.
+    """
+    return [
+        expected
+        for expected in expected_objects
+        if not any(object_matches(row, expected) for row in results)
+    ]

--- a/viewer/tests/test_api_upload_target_experiments_async.py
+++ b/viewer/tests/test_api_upload_target_experiments_async.py
@@ -23,6 +23,7 @@ which must include the manifest's TAS; the upload itself runs with the stack's
 import json
 import os
 import time
+import warnings
 from typing import List, Optional
 
 import pytest
@@ -177,11 +178,21 @@ def test_upload_poll_then_get(tmp_path):
     assert targets["count"] == expect["targets"]
 
     for key, url in COUNT_ENDPOINTS.items():
+        body = _get_json(http, f"{base_url}{url}")
+        observed = body["count"]
         expected_count = expect.get(key)
         if expected_count is None:
+            # The manifest has no count for this endpoint yet. Don't assert -
+            # surface the observed count so it can be filled into the manifest
+            # (see "Adding a new dataset" in INTEGRATION-TESTS.md). The warning
+            # shows in pytest's summary even on an otherwise-passing run, so a
+            # single CI run reveals every count waiting to be pinned down.
+            warnings.warn(
+                f"{key}: manifest count is null; observed {observed} at {url}",
+                stacklevel=2,
+            )
             continue
-        body = _get_json(http, f"{base_url}{url}")
-        assert body["count"] == expected_count, url
+        assert observed == expected_count, url
 
     # Content assertions: beyond the bare counts, the manifest can name specific
     # objects (as field-subsets) it expects an endpoint to return for this

--- a/viewer/tests/test_api_upload_target_experiments_async.py
+++ b/viewer/tests/test_api_upload_target_experiments_async.py
@@ -46,6 +46,11 @@ BASE_URL_ENV = "INTEGRATION_BASE_URL"
 POLL_TIMEOUT_SECONDS = 30 * 60
 POLL_INTERVAL_SECONDS = 5
 
+#: Per-request read timeout (seconds). The whole load completes in a few minutes
+#: and every GET is sub-second, so a request that goes this long with no data is
+#: wedged - fail loudly rather than hang the unattended CI job indefinitely.
+REQUEST_READ_TIMEOUT_SECONDS = 120.0
+
 #: Endpoints whose ``count`` is asserted against the manifest. These are the
 #: model objects a target load produces, beyond the target itself. Each key
 #: must match a manifest ``expect`` key; a null/absent value turns the
@@ -142,7 +147,15 @@ def _poll_until_finished(http: urllib3.PoolManager, status_url: str) -> dict:
 def test_upload_poll_then_get(tmp_path):
     """Upload over HTTP, poll to SUCCESS, then assert the GET endpoints match."""
     base_url = _base_url()
-    http = urllib3.PoolManager()
+    # A read timeout is essential: every request below is unattended in CI, so a
+    # slow or wedged endpoint must fail the test loudly rather than hang the job
+    # for hours. The read timeout is the gap allowed *between* bytes, so it does
+    # not penalise a large-but-steady upload; retries are off so a stuck request
+    # surfaces immediately instead of being silently retried.
+    http = urllib3.PoolManager(
+        timeout=urllib3.Timeout(connect=15.0, read=REQUEST_READ_TIMEOUT_SECONDS),
+        retries=False,
+    )
 
     entry = load_manifest(ENDPOINT)
     identifier = data_identifier()

--- a/viewer/tests/test_api_upload_target_experiments_async.py
+++ b/viewer/tests/test_api_upload_target_experiments_async.py
@@ -23,6 +23,7 @@ which must include the manifest's TAS; the upload itself runs with the stack's
 import json
 import os
 import time
+from typing import List, Optional
 
 import pytest
 import urllib3
@@ -31,6 +32,7 @@ from viewer.tests.external_data import (
     data_identifier,
     download,
     load_manifest,
+    missing_objects,
     requires_external_data,
 )
 
@@ -43,11 +45,32 @@ BASE_URL_ENV = "INTEGRATION_BASE_URL"
 POLL_TIMEOUT_SECONDS = 30 * 60
 POLL_INTERVAL_SECONDS = 5
 
+#: Endpoints whose ``count`` is asserted against the manifest. These are the
+#: model objects a target load produces, beyond the target itself. Each key
+#: must match a manifest ``expect`` key; a null/absent value turns the
+#: assertion off (see the manifest header), so new endpoints can land here and
+#: gain assertions as the real counts are filled in.
 COUNT_ENDPOINTS = {
     "experiments": "/api/experiments/",
     "site_observations": "/api/site_observations/",
+    "canon_sites": "/api/canon_sites/",
+    "canon_site_confs": "/api/canon_site_confs/",
+    "xtalform_sites": "/api/xtalform_sites/",
     "poses": "/api/poses/",
     "target_experiment_uploads": "/api/target_experiment_uploads/",
+}
+
+#: Endpoints whose returned *objects* can be content-checked against the
+#: manifest ``expect.objects`` section (each entry is a field-subset that must
+#: match some returned object). Keyed by the manifest endpoint name.
+OBJECT_ENDPOINTS = {
+    "targets": "/api/targets/",
+    "experiments": "/api/experiments/",
+    "site_observations": "/api/site_observations/",
+    "canon_sites": "/api/canon_sites/",
+    "canon_site_confs": "/api/canon_site_confs/",
+    "xtalform_sites": "/api/xtalform_sites/",
+    "poses": "/api/poses/",
 }
 
 pytestmark = pytest.mark.integration
@@ -68,6 +91,22 @@ def _get_json(http: urllib3.PoolManager, url: str) -> dict:
     if response.status != 200:
         raise RuntimeError(f"GET {url} returned HTTP {response.status}")
     return json.loads(response.data.decode("utf-8"))
+
+
+def _get_all_results(http: urllib3.PoolManager, url: str) -> list:
+    """Return every ``results`` row from a paginated DRF list endpoint.
+
+    Content assertions must search the whole result set, not just the first
+    page, so follow the absolute ``next`` link the pagination emits until it is
+    null. ``next`` URLs are absolute, so they are requested verbatim.
+    """
+    results: List[dict] = []
+    next_url: Optional[str] = url
+    while next_url:
+        body = _get_json(http, next_url)
+        results.extend(body["results"])
+        next_url = body.get("next")
+    return results
 
 
 def _poll_until_finished(http: urllib3.PoolManager, status_url: str) -> dict:
@@ -143,3 +182,21 @@ def test_upload_poll_then_get(tmp_path):
             continue
         body = _get_json(http, f"{base_url}{url}")
         assert body["count"] == expected_count, url
+
+    # Content assertions: beyond the bare counts, the manifest can name specific
+    # objects (as field-subsets) it expects an endpoint to return for this
+    # identifier. Scan every page and fail loudly with the unmatched
+    # expectations if any are missing.
+    expected_objects = expect.get("objects") or {}
+    for key, expected_list in expected_objects.items():
+        if not expected_list:
+            continue
+        object_url = OBJECT_ENDPOINTS.get(key)
+        assert (
+            object_url is not None
+        ), f"manifest 'objects' names unknown endpoint {key!r}"
+        results = _get_all_results(http, f"{base_url}{object_url}")
+        missing = missing_objects(results, expected_list)
+        assert (
+            not missing
+        ), f"{key}: expected objects not found in {object_url}: {missing}"

--- a/viewer/tests/test_data/api/upload_target_experiments/manifest.yaml
+++ b/viewer/tests/test_data/api/upload_target_experiments/manifest.yaml
@@ -21,6 +21,15 @@
 # asserted; the remaining counts are only asserted when non-null, so a new
 # identifier can start with placeholders and gain assertions as the real
 # numbers are filled in.
+#
+# `expect.objects` (optional) adds CONTENT assertions on top of the counts: for
+# each endpoint it lists the object(s) that endpoint must return for this
+# identifier. Each entry is a FIELD-SUBSET - only the fields you name are
+# compared, and the returned object may carry many more. The whole (paginated)
+# result set is searched, and the test fails naming any expectation not found.
+# Endpoint names: targets, experiments, site_observations, canon_sites,
+# canon_site_confs, xtalform_sites, poses. Fill these in with real values
+# captured from a stack run, exactly as the counts were.
 
 ALPHA:
   uploads:
@@ -31,5 +40,16 @@ ALPHA:
     targets: 1
     experiments: 7642
     site_observations: 67
+    # The remaining model objects a target load produces. Counts captured from
+    # a stack run turn each assertion on (null = not yet asserted).
+    canon_sites: null
+    canon_site_confs: null
+    xtalform_sites: null
     poses: 62
     target_experiment_uploads: 1
+    objects:
+      # The loaded target appears in /api/targets/ under its title. Add
+      # site_observations/poses/etc. entries here with real codes from a stack
+      # run to content-check the other model objects.
+      targets:
+        - title: A71EV2A

--- a/viewer/tests/test_data/api/upload_target_experiments/manifest.yaml
+++ b/viewer/tests/test_data/api/upload_target_experiments/manifest.yaml
@@ -40,11 +40,12 @@ ALPHA:
     targets: 1
     experiments: 7642
     site_observations: 67
-    # The remaining model objects a target load produces. Counts captured from
-    # a stack run turn each assertion on (null = not yet asserted).
-    canon_sites: null
-    canon_site_confs: null
-    xtalform_sites: null
+    # The remaining model objects a target load produces; counts captured from
+    # a `build dev` integration run (the test surfaces these as warnings while
+    # they are null - see INTEGRATION-TESTS.md "Adding a new dataset").
+    canon_sites: 11
+    canon_site_confs: 14
+    xtalform_sites: 21
     poses: 62
     target_experiment_uploads: 1
     objects:

--- a/viewer/tests/test_external_data.py
+++ b/viewer/tests/test_external_data.py
@@ -50,3 +50,50 @@ def test_external_data_disabled_with_only_one_env(monkeypatch):
     monkeypatch.setenv(external_data.BUCKET_AND_PATH_ENV, "s3://bucket/prefix")
     monkeypatch.delenv(external_data.DATA_IDENTIFIER_ENV, raising=False)
     assert external_data.external_data_enabled() is False
+
+
+# --- object_matches / missing_objects --------------------------------------
+#
+# These back the integration test's content assertions: a manifest names the
+# objects (as field-subsets) it expects each endpoint to return, and these
+# helpers decide whether a returned object satisfies an expectation.
+
+
+def test_object_matches_subset_with_extra_fields():
+    # The returned object carries extra fields; only the expected subset matters.
+    row = {"code": "x0123a", "compound_code": "Z42", "id": 7}
+    assert external_data.object_matches(row, {"code": "x0123a"}) is True
+    assert (
+        external_data.object_matches(row, {"code": "x0123a", "compound_code": "Z42"})
+        is True
+    )
+
+
+def test_object_matches_empty_expectation_matches_anything():
+    assert external_data.object_matches({"code": "x0123a"}, {}) is True
+
+
+def test_object_matches_rejects_missing_key():
+    assert (
+        external_data.object_matches({"code": "x0123a"}, {"compound_code": "Z42"})
+        is False
+    )
+
+
+def test_object_matches_rejects_value_mismatch():
+    assert external_data.object_matches({"code": "x0123a"}, {"code": "other"}) is False
+
+
+def test_missing_objects_returns_empty_when_all_found():
+    results = [{"code": "a", "id": 1}, {"code": "b", "id": 2}]
+    expected = [{"code": "a"}, {"code": "b"}]
+    assert external_data.missing_objects(results, expected) == []
+
+
+def test_missing_objects_returns_the_unmatched_expectations():
+    results = [{"code": "a", "id": 1}]
+    expected = [{"code": "a"}, {"code": "b"}, {"code": "c"}]
+    assert external_data.missing_objects(results, expected) == [
+        {"code": "b"},
+        {"code": "c"},
+    ]


### PR DESCRIPTION
Fixes #968

## What

Extends the manifest-driven target-loader **integration test**
(`test_api_upload_target_experiments_async.py`) so it verifies the *additional*
model objects a target load produces and can content-check the objects an
endpoint returns — all conditioned on the data identity (**ALPHA**, **BRAVO**,
…) through the per-endpoint `manifest.yaml`, exactly as the issue describes.

## Changes

- **More related-endpoint counts.** Adds `canon_sites`, `canon_site_confs` and
  `xtalform_sites` to the asserted counts (alongside the existing experiments /
  site_observations / poses / target_experiment_uploads). They sit in the ALPHA
  manifest as `null` placeholders and turn on once the real numbers are captured
  from a stack run — the same "fill-in-later" convention the existing counts use.
- **Object content assertions.** Adds an optional `expect.objects` manifest
  section: under each endpoint name you list one or more **field-subsets** that
  must each match some returned object. The test pages through the endpoint's
  full result set and fails naming any expectation it can't find. ALPHA ships a
  real, known assertion (`targets: [{title: A71EV2A}]`) so the new path is
  genuinely exercised in CI; site-observation/pose codes etc. can be added from a
  stack run.
- **Pure, unit-tested helpers.** The matching logic (`object_matches`,
  `missing_objects`) lives in `viewer/tests/external_data.py` and is covered by
  new tests in `test_external_data.py`. Those run in the **normal** suite; the
  integration test itself stays env-gated and deselected by default.
- **Docs.** `INTEGRATION-TESTS.md` and the manifest header document the new count
  keys and the `objects` content assertions.

## Testing

- `pytest viewer/tests/test_external_data.py` — 15 passed (incl. the 6 new
  helper tests).
- Integration test collects cleanly under `-m integration`; manifest parses.
- `pre-commit run --files …` — all hooks pass (black/isort/mypy/pylint).

The integration test runs only inside `docker-compose.integration.yml`
(env-gated on `INTEGRATION_BASE_URL` + the external-data vars), so the new
assertions execute on the integration CI job, not the host/CI unit run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
