### PR TITLE
fix(980): handle unreachable neo4j graph gracefully in service probe

### DIFF
--- a/service_status/services.py
+++ b/service_status/services.py
@@ -5,6 +5,7 @@ from random import random
 import requests
 from django.conf import settings
 from fragutils.utils.network_utils import get_driver
+from neo4j.exceptions import Neo4jError, ServiceUnavailable
 from pydiscourse import DiscourseClient
 
 from api.security import ping_configured_connector
@@ -90,6 +91,18 @@ def fragmentation_graph() -> str:
             return State.OK
         except ValueError:
             # service isn't running
+            return State.DEGRADED
+        except (ServiceUnavailable, Neo4jError) as graph_exc:
+            # The graph being unreachable is an expected, recoverable state
+            # (e.g. neo4j down during an outage). Without this the neo4j
+            # exception would propagate out of the probe and APScheduler would
+            # log a full traceback on every scheduled run. Log one concise line
+            # naming the failure and report DEGRADED (see issue #980).
+            logger.error(
+                "fragmentation_graph: %s: %s",
+                type(graph_exc).__name__,
+                graph_exc,
+            )
             return State.DEGRADED
 
 

--- a/viewer/tests/test_service_status.py
+++ b/viewer/tests/test_service_status.py
@@ -1,0 +1,75 @@
+"""Regression tests for service_status probe error handling (issue #980).
+
+When neo4j is unreachable the ``fragmentation_graph`` probe used to let the
+neo4j ``ServiceUnavailable`` exception propagate out of the probe. APScheduler
+then logged a full, multi-frame traceback every 30s (see the stack-0 logs after
+the h/w outage of 18 June 2026). The probe must instead catch that exception,
+log a single concise line, and report ``DEGRADED``.
+"""
+import logging
+from contextlib import contextmanager
+
+from neo4j.exceptions import ServiceUnavailable
+
+from service_status import services
+from service_status.utils import State
+
+
+class _FakeSession:
+    """A neo4j session whose ``run`` always raises the given exception."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    def run(self, *_args, **_kwargs):
+        raise self._exc
+
+
+class _FakeDriver:
+    """A neo4j driver handing out sessions that fail on ``run``."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    @contextmanager
+    def session(self):
+        yield _FakeSession(self._exc)
+
+
+# The probe is wrapped by @service_query (which touches the DB); exercise the
+# underlying function directly via the reference functools.wraps leaves behind.
+fragmentation_graph = services.fragmentation_graph.__wrapped__
+
+_UNAVAILABLE = ServiceUnavailable("Couldn't connect to graph.graph-x.svc:7687")
+
+
+def test_fragmentation_graph_degraded_when_graph_unavailable(monkeypatch):
+    """An unreachable graph is reported as DEGRADED, not raised."""
+    monkeypatch.setattr(
+        services, "get_driver", lambda **_kwargs: _FakeDriver(_UNAVAILABLE)
+    )
+
+    # Must not raise, and must report DEGRADED.
+    assert fragmentation_graph() == State.DEGRADED
+
+
+def test_fragmentation_graph_logs_concise_message(monkeypatch, caplog):
+    """The unreachable graph is logged as one concise line, no traceback."""
+    monkeypatch.setattr(
+        services, "get_driver", lambda **_kwargs: _FakeDriver(_UNAVAILABLE)
+    )
+
+    # The 'service_status' logger is configured with propagate=False, so its
+    # records never reach caplog's root handler. Enable propagation for the
+    # duration of the test (monkeypatch restores it) so caplog can see them.
+    service_logger = logging.getLogger("service_status")
+    monkeypatch.setattr(service_logger, "propagate", True)
+
+    with caplog.at_level("WARNING", logger="service_status"):
+        fragmentation_graph()
+
+    # A single record naming the failure (matching the issue's desired text),
+    # and crucially no exception traceback attached to it.
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("ServiceUnavailable" in message for message in messages)
+    assert all(record.exc_info is None for record in caplog.records)


### PR DESCRIPTION
Fixes #980

## Problem

When neo4j is unreachable (as during the h/w outage of 18 June 2026) the
`fragmentation_graph` service probe only caught `ValueError`. The neo4j driver
raises `neo4j.exceptions.ServiceUnavailable`, which propagated out of the probe.
APScheduler then logged a **full multi-frame traceback on every scheduled run**
(every 30s), flooding the `stack-0` logs.

## Fix

Catch `ServiceUnavailable` / `Neo4jError` in the probe, log a single concise
line, and report `DEGRADED`. The graph being down is an expected, recoverable
state, so the probe now logs e.g.:

```
fragmentation_graph: ServiceUnavailable: Couldn't connect to graph.graph-x.svc:7687
```

instead of a stack trace.

## Tests

Added `viewer/tests/test_service_status.py` (TDD — written first, watched fail):

- the probe reports `DEGRADED` instead of raising when the graph is unreachable;
- the failure is logged as one concise line naming the exception, with no
  traceback attached to the record.

Full suite: 132 passed, 2 pre-existing skips. `pre-commit` clean.
