### PR TITLE
fix(982): activate requested services in init_services()

### DIFF
--- a/service_status/utils.py
+++ b/service_status/utils.py
@@ -117,10 +117,25 @@ def init_services():
         if service.service not in defined:
             service.delete()
 
-    # mark those not requested as NOT_CONFIGURED
+    # Reconcile every service's state against ENABLE_SERVICE_STATUS, in BOTH
+    # directions, so the setting is the single source of truth for which
+    # probes run:
+    #   - a service NOT requested is disabled (set NOT_CONFIGURED);
+    #   - a service that IS requested but is currently NOT_CONFIGURED (a fresh
+    #     row defaults to NOT_CONFIGURED, or it was disabled on a prior run) is
+    #     activated, mirroring services(enable=...). Without this it would stay
+    #     NOT_CONFIGURED forever and the probe would self-skip (see #982).
+    # An already-active requested service is left as-is, so a healthy OK/ERROR
+    # state is not clobbered back to DEGRADED on every restart.
+    not_configured = ServiceState.objects.get(state=State.NOT_CONFIGURED)
+    degraded = ServiceState.objects.get(state=State.DEGRADED)
     for service in Service.objects.all():
         if service.service not in requested_services:
-            service.last_state = ServiceState.objects.get(state=State.NOT_CONFIGURED)
+            if service.last_state_id != State.NOT_CONFIGURED:
+                service.last_state = not_configured
+                service.save()
+        elif service.last_state_id == State.NOT_CONFIGURED:
+            service.last_state = degraded
             service.save()
 
     # Now start the scheduler and add jobs for requested services

--- a/viewer/tests/test_service_status_init.py
+++ b/viewer/tests/test_service_status_init.py
@@ -1,0 +1,72 @@
+"""Tests for service_status.init_services activation logic (issue #982).
+
+`init_services()` reconciles the Service table against the
+`ENABLE_SERVICE_STATUS` setting. It used to only *demote* services missing from
+the list to NOT_CONFIGURED; it never *promoted* a requested service out of
+NOT_CONFIGURED. Because a Service row defaults to NOT_CONFIGURED and the probe
+self-skips in that state, a requested service could stay NOT_CONFIGURED forever.
+These tests pin down that a requested service is activated, while an already
+active one is left untouched, and an unrequested one is disabled.
+"""
+# Fixtures legitimately reuse their own name as a test argument, are requested
+# for their side effect only, and reach for a module "constant" deliberately -
+# all standard pytest patterns that pylint misreads (cf. conftest.py).
+# pylint: disable=redefined-outer-name,unused-argument,protected-access
+import pytest
+
+from service_status import utils
+from service_status.models import Service, ServiceState
+from service_status.utils import State, init_services
+
+
+def _set_state(service_name: str, state: State, display_name: str = "x") -> None:
+    """Create (or reset) a Service row in a known state."""
+    Service.objects.update_or_create(
+        service=service_name,
+        defaults={
+            "display_name": display_name,
+            "last_state": ServiceState.objects.get(state=state),
+        },
+    )
+
+
+@pytest.fixture
+def as_service_check_host(monkeypatch, settings):
+    """Run init_services as the check host, without a real scheduler."""
+    monkeypatch.setattr(utils, "_HOSTNAME", utils._SERVICE_CHECK_HOSTNAME)
+    settings.SERVICE_STATUS_SCHEDULER_ENABLED = False
+    settings.ENABLE_SERVICE_STATUS = "fragmentation_graph:ispyb:keycloak:squonk"
+
+
+@pytest.mark.django_db
+def test_requested_not_configured_service_is_activated(as_service_check_host):
+    """A requested service stuck at NOT_CONFIGURED is promoted to DEGRADED."""
+    _set_state("fragmentation_graph", State.NOT_CONFIGURED, "Fragmentation graph")
+
+    init_services()
+
+    service = Service.objects.get(service="fragmentation_graph")
+    assert service.last_state_id == State.DEGRADED
+
+
+@pytest.mark.django_db
+def test_already_active_requested_service_is_preserved(as_service_check_host):
+    """An active requested service is not reset (e.g. OK must stay OK)."""
+    _set_state("ispyb", State.OK, "Access control (ISPyB)")
+
+    init_services()
+
+    service = Service.objects.get(service="ispyb")
+    assert service.last_state_id == State.OK
+
+
+@pytest.mark.django_db
+def test_unrequested_service_is_disabled(as_service_check_host):
+    """A service absent from ENABLE_SERVICE_STATUS is set NOT_CONFIGURED."""
+    # 'discourse' is defined in services.py but not in the requested list.
+    _set_state("discourse", State.OK, "Discourse")
+
+    init_services()
+
+    service = Service.objects.get(service="discourse")
+    assert service.last_state_id == State.NOT_CONFIGURED


### PR DESCRIPTION
Fixes #982

## Problem

`init_services()` reconciled the `Service` table against `ENABLE_SERVICE_STATUS`
in **one direction only**: it demoted services missing from the list to
`NOT_CONFIGURED`, but never promoted a requested service *out of*
`NOT_CONFIGURED`. Because a `Service` row defaults to `NOT_CONFIGURED` and the
`@service_query` probe self-skips in that state, a requested service (e.g.
`fragmentation_graph`) could sit at `NOT_CONFIGURED` indefinitely — its
scheduler job fired every 30s but bailed at the guard without ever probing or
updating. Enabling a service therefore required a separate, manual
`manage.py services --enable …`.

## Fix

Reconcile **both** directions in `init_services()`:

- a service **not** in `ENABLE_SERVICE_STATUS` → `NOT_CONFIGURED` (as before);
- a service that **is** requested but currently `NOT_CONFIGURED` → `DEGRADED`,
  mirroring `services(enable=...)`.

An already-active requested service is left untouched, so a healthy `OK`/`ERROR`
state is not clobbered back to `DEGRADED` on every restart.

`ENABLE_SERVICE_STATUS` is now the single source of truth for which probes run,
with no manual enable step.

## Tests

New `viewer/tests/test_service_status_init.py` (TDD — activation test written
first, watched fail):

- a requested `NOT_CONFIGURED` service is promoted to `DEGRADED`;
- an already-active requested service (`OK`) is preserved;
- an unrequested service is set `NOT_CONFIGURED`.

Full suite: 133 passed, 2 pre-existing skips. `pre-commit` clean.

## Notes

A separate file from #981's `test_service_status.py` to avoid a merge conflict
while that PR is still open. Found while debugging the `fragmentation_graph`
`NOT_CONFIGURED` report alongside #980 / #981.
