### PR TITLE
test(984): coverage gate and shared mock fixtures (phase 1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,19 +103,26 @@ testpaths = ["viewer/tests"]
 # -m "not integration": the async integration test needs the live container
 #   stack (redis + celery worker) and is never collected by the default/host
 #   run; the integration compose runs it explicitly with -m integration.
-addopts = "--reuse-db --strict-markers -m \"not integration\" --cov=viewer --cov-report=term-missing --cov-report=html"
+addopts = "--reuse-db --strict-markers -m \"not integration\" --cov=viewer --cov=api --cov=service_status --cov=network --cov=media_serve --cov=scoring --cov=hotspots --cov=hypothesis --cov=fragalysis --cov-report=term-missing --cov-report=html"
 markers = [
     "integration: needs the live container stack (redis + celery worker)",
 ]
 
 [tool.coverage.run]
-# Coverage measures the viewer app's hand-written code. Auto-generated
+# Coverage measures the first-party apps' hand-written code. Auto-generated
 # migrations (excluded from all lint hooks too) and the tests themselves
 # would otherwise distort the headline figure.
 omit = [
-    "viewer/migrations/*",
-    "viewer/tests/*",
+    "*/migrations/*",
+    "*/tests/*",
 ]
+
+[tool.coverage.report]
+# A non-regression ratchet, not an aspirational target: keep coverage from
+# slipping below where it stands today. Raise this as new tests land (see
+# issue #984's phased plan). pytest exits non-zero when the total drops below
+# this floor, which fails the CI 'Unit tests (pytest)' step.
+fail_under = 35
 
 [tool.coverage.html]
 directory = "htmlcov"

--- a/viewer/tests/conftest.py
+++ b/viewer/tests/conftest.py
@@ -10,7 +10,9 @@ set will arrive once a real target archive is committed and loaded via the
 # arguments, and the `db`/blocker fixtures are requested for their side effect
 # only - both are standard pytest patterns that pylint misreads.
 # pylint: disable=redefined-outer-name,unused-argument
+from contextlib import contextmanager
 from typing import Callable, Iterable
+from unittest import mock
 
 import pytest
 import ta_auth_connector
@@ -128,5 +130,110 @@ def mock_target_access(monkeypatch) -> Callable[[Iterable[str]], None]:
             "get_auth_target_access",
             lambda username: set(proposal_set),
         )
+
+    return _set
+
+
+class _FakeNeo4jSession:
+    """A neo4j session whose ``run`` raises a chosen exception, or no-ops.
+
+    With ``exc=None`` the session behaves as a reachable graph (``run``
+    returns ``None``); pass an exception to simulate an unreachable graph.
+    """
+
+    def __init__(self, exc: Exception | None):
+        self._exc = exc
+
+    def run(self, *_args, **_kwargs):
+        if self._exc is not None:
+            raise self._exc
+        return None
+
+
+class _FakeNeo4jDriver:
+    """A neo4j driver handing out :class:`_FakeNeo4jSession` instances."""
+
+    def __init__(self, exc: Exception | None):
+        self._exc = exc
+
+    @contextmanager
+    def session(self):
+        yield _FakeNeo4jSession(self._exc)
+
+
+@pytest.fixture
+def mock_neo4j(monkeypatch) -> Callable[..., None]:
+    """Patch the neo4j driver seam used by the service-status probes.
+
+    ``service_status.services.get_driver`` is the single point where a real
+    neo4j connection is opened. This fixture returns a setter that replaces it
+    with a fake driver, so probe tests never touch a real graph. Call with no
+    argument for a reachable graph, or pass an exception (e.g.
+    ``neo4j.exceptions.ServiceUnavailable(...)``) to simulate an outage.
+    """
+
+    def _set(exc: Exception | None = None) -> None:
+        from service_status import services
+
+        monkeypatch.setattr(
+            services, "get_driver", lambda **_kwargs: _FakeNeo4jDriver(exc)
+        )
+
+    return _set
+
+
+@pytest.fixture
+def mock_async_result(monkeypatch) -> Callable[..., mock.Mock]:
+    """Patch ``viewer.download_structures.AsyncResult`` to a fixed state.
+
+    The download housekeeping/capacity logic inspects a Celery
+    ``AsyncResult``'s ``state`` and ``info`` to decide whether a download task
+    is still running, lost, or failed. This fixture returns a setter that makes
+    every ``AsyncResult(...)`` return a stub with the given ``state``/``info``,
+    so tests need no broker or worker.
+
+    The *constructor* mock is returned (mirroring ``mocker.patch.object``), so a
+    test can assert whether the result backend was consulted at all (e.g.
+    ``async_result.assert_not_called()``); the stub result is reachable via its
+    ``.return_value``.
+    """
+
+    def _set(state: str, info=None) -> mock.Mock:
+        from viewer import download_structures
+
+        result = mock.Mock()
+        result.state = state
+        result.info = info
+        constructor = mock.Mock(return_value=result)
+        monkeypatch.setattr(download_structures, "AsyncResult", constructor)
+        return constructor
+
+    return _set
+
+
+@pytest.fixture
+def mock_squonk_agent(monkeypatch) -> Callable[..., mock.Mock]:
+    """Patch the Squonk2 agent singleton used by ``squonk_job_request``.
+
+    ``viewer.squonk_job_request`` binds a module-level ``Squonk2Agent``
+    singleton (``_SQ2A``) at import time. This fixture returns a setter that
+    swaps it for a ``Mock`` whose ``ping``/``ensure_project`` (etc.) return a
+    ``Squonk2AgentRv``-shaped value, so the validation/error branches can be
+    exercised without a live Data-Manager/Account-Server API. The stub agent
+    mock is returned so a test can tailor individual method return values.
+    """
+
+    def _set(**method_return_values) -> mock.Mock:
+        from viewer import squonk_job_request
+        from viewer.squonk2_agent import SuccessRv
+
+        agent = mock.Mock()
+        # Default every called method to "success" unless overridden.
+        agent.ping.return_value = SuccessRv
+        agent.ensure_project.return_value = SuccessRv
+        for name, value in method_return_values.items():
+            getattr(agent, name).return_value = value
+        monkeypatch.setattr(squonk_job_request, "_SQ2A", agent)
+        return agent
 
     return _set

--- a/viewer/tests/test_download_housekeeping.py
+++ b/viewer/tests/test_download_housekeeping.py
@@ -31,23 +31,15 @@ def _make_link(
     )
 
 
-def _patch_state(mocker, state, info=None):
-    """Make AsyncResult(...).state/.info return the given values."""
-    result = mocker.Mock()
-    result.state = state
-    result.info = info
-    return mocker.patch.object(download_structures, "AsyncResult", return_value=result)
-
-
 @pytest.fixture
 def now():
     return datetime.now(timezone.utc)
 
 
 @pytest.mark.django_db
-def test_within_start_grace_is_left_alone(mocker, now):
+def test_within_start_grace_is_left_alone(mock_async_result, now):
     """A young record is given time to start - not even queried."""
-    async_result = _patch_state(mocker, "PENDING")
+    async_result = mock_async_result("PENDING")
     link = _make_link(now - timedelta(minutes=1))
 
     download_structures.expire_lost_download_records()
@@ -60,8 +52,8 @@ def test_within_start_grace_is_left_alone(mocker, now):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("state", ["FAILURE", "REVOKED"])
-def test_failed_task_is_expired(mocker, now, state):
-    _patch_state(mocker, state, info="boom")
+def test_failed_task_is_expired(mock_async_result, now, state):
+    mock_async_result(state, info="boom")
     link = _make_link(now - timedelta(minutes=10))
 
     download_structures.expire_lost_download_records()
@@ -73,9 +65,9 @@ def test_failed_task_is_expired(mocker, now, state):
 
 
 @pytest.mark.django_db
-def test_pending_task_is_expired_as_lost(mocker, now):
+def test_pending_task_is_expired_as_lost(mock_async_result, now):
     """PENDING past the grace means no worker result - the task is lost."""
-    _patch_state(mocker, "PENDING")
+    mock_async_result("PENDING")
     link = _make_link(now - timedelta(minutes=10))
 
     download_structures.expire_lost_download_records()
@@ -86,9 +78,9 @@ def test_pending_task_is_expired_as_lost(mocker, now):
 
 
 @pytest.mark.django_db
-def test_running_within_max_runtime_is_left_alone(mocker, now):
+def test_running_within_max_runtime_is_left_alone(mock_async_result, now):
     """A genuinely long-running download must not be killed prematurely."""
-    _patch_state(mocker, "PROCESSING")
+    mock_async_result("PROCESSING")
     link = _make_link(now - timedelta(minutes=10))
 
     download_structures.expire_lost_download_records()
@@ -99,10 +91,10 @@ def test_running_within_max_runtime_is_left_alone(mocker, now):
 
 
 @pytest.mark.django_db
-def test_running_beyond_max_runtime_is_expired(mocker, now):
+def test_running_beyond_max_runtime_is_expired(mock_async_result, now):
     """A 'running' task older than the max runtime is presumed lost (frozen
     result after a worker restart)."""
-    _patch_state(mocker, "PROCESSING")
+    mock_async_result("PROCESSING")
     link = _make_link(now - timedelta(minutes=90))
 
     download_structures.expire_lost_download_records()
@@ -113,9 +105,9 @@ def test_running_beyond_max_runtime_is_expired(mocker, now):
 
 
 @pytest.mark.django_db
-def test_no_task_id_is_expired(mocker, now):
+def test_no_task_id_is_expired(mock_async_result, now):
     """A record past the grace that never got a task_id was never launched."""
-    async_result = _patch_state(mocker, "PENDING")
+    async_result = mock_async_result("PENDING")
     link = _make_link(now - timedelta(minutes=10), task_id=None)
 
     download_structures.expire_lost_download_records()
@@ -127,9 +119,9 @@ def test_no_task_id_is_expired(mocker, now):
 
 
 @pytest.mark.django_db
-def test_completed_record_is_not_a_candidate(mocker, now):
+def test_completed_record_is_not_a_candidate(mock_async_result, now):
     """A record with keep_zip_until set has finished and is ignored here."""
-    async_result = _patch_state(mocker, "FAILURE")
+    async_result = mock_async_result("FAILURE")
     link = _make_link(
         now - timedelta(minutes=10), keep_zip_until=now + timedelta(minutes=30)
     )
@@ -142,8 +134,8 @@ def test_completed_record_is_not_a_candidate(mocker, now):
 
 
 @pytest.mark.django_db
-def test_static_link_is_left_alone(mocker, now):
-    async_result = _patch_state(mocker, "FAILURE")
+def test_static_link_is_left_alone(mock_async_result, now):
+    async_result = mock_async_result("FAILURE")
     link = _make_link(now - timedelta(minutes=10), static_link=True)
 
     download_structures.expire_lost_download_records()

--- a/viewer/tests/test_service_status.py
+++ b/viewer/tests/test_service_status.py
@@ -7,34 +7,11 @@ the h/w outage of 18 June 2026). The probe must instead catch that exception,
 log a single concise line, and report ``DEGRADED``.
 """
 import logging
-from contextlib import contextmanager
 
 from neo4j.exceptions import ServiceUnavailable
 
 from service_status import services
 from service_status.utils import State
-
-
-class _FakeSession:
-    """A neo4j session whose ``run`` always raises the given exception."""
-
-    def __init__(self, exc):
-        self._exc = exc
-
-    def run(self, *_args, **_kwargs):
-        raise self._exc
-
-
-class _FakeDriver:
-    """A neo4j driver handing out sessions that fail on ``run``."""
-
-    def __init__(self, exc):
-        self._exc = exc
-
-    @contextmanager
-    def session(self):
-        yield _FakeSession(self._exc)
-
 
 # The probe is wrapped by @service_query (which touches the DB); exercise the
 # underlying function directly via the reference functools.wraps leaves behind.
@@ -43,21 +20,17 @@ fragmentation_graph = services.fragmentation_graph.__wrapped__
 _UNAVAILABLE = ServiceUnavailable("Couldn't connect to graph.graph-x.svc:7687")
 
 
-def test_fragmentation_graph_degraded_when_graph_unavailable(monkeypatch):
+def test_fragmentation_graph_degraded_when_graph_unavailable(mock_neo4j):
     """An unreachable graph is reported as DEGRADED, not raised."""
-    monkeypatch.setattr(
-        services, "get_driver", lambda **_kwargs: _FakeDriver(_UNAVAILABLE)
-    )
+    mock_neo4j(_UNAVAILABLE)
 
     # Must not raise, and must report DEGRADED.
     assert fragmentation_graph() == State.DEGRADED
 
 
-def test_fragmentation_graph_logs_concise_message(monkeypatch, caplog):
+def test_fragmentation_graph_logs_concise_message(mock_neo4j, monkeypatch, caplog):
     """The unreachable graph is logged as one concise line, no traceback."""
-    monkeypatch.setattr(
-        services, "get_driver", lambda **_kwargs: _FakeDriver(_UNAVAILABLE)
-    )
+    mock_neo4j(_UNAVAILABLE)
 
     # The 'service_status' logger is configured with propagate=False, so its
     # records never reach caplog's root handler. Enable propagation for the


### PR DESCRIPTION
Part of #984 — **Phase 1** of the staged test-coverage plan: test
infrastructure and a non-regression coverage gate, plus the shared mock
fixtures that unblock the later phases. No production code changes.

## What this does

- **Broadens coverage scope.** `--cov` now measures every first-party app
  (`viewer`, `api`, `service_status`, `network`, `media_serve`, `scoring`,
  `hotspots`, `hypothesis`, `fragalysis`), not just `viewer`. The `omit` list is
  generalised to every app's `migrations/` and `tests/`.
- **Adds a ratcheted coverage gate.** `[tool.coverage.report] fail_under = 35`.
  The current measured total is **36.59%**, so this is a non-regression floor
  (not an aspirational target). pytest exits non-zero below it, which fails the
  CI *Unit tests (pytest)* step automatically — no new CI step needed. Raise the
  floor as phases 2–3 add tests.
- **Centralises external-service mock fixtures** in `viewer/tests/conftest.py`,
  promoting patterns already proven ad-hoc in the suite:
  - `mock_neo4j` — fake neo4j driver for the service-status probes (reachable or
    raising a chosen exception).
  - `mock_async_result` — fixes a Celery `AsyncResult`'s `state`/`info` so
    download housekeeping/capacity tests need no broker or worker.
  - `mock_squonk_agent` — stubs the `squonk_job_request` `Squonk2Agent`
    singleton so the validation/error branches can be exercised without a live
    DM/AS API.
- **Refactors** `test_service_status.py` and `test_download_housekeeping.py`
  onto the shared fixtures, proving them and removing the duplicated local
  fakes/helpers.

## Verification

- `./run-unit-tests.sh` (full suite against the PostgreSQL test container):
  **135 passed, 1 skipped, 1 deselected**; gate reports
  *"Required test coverage of 35.0% reached. Total coverage: 36.59%"*.
- `pre-commit run --files …` on the changed `viewer` files — all hooks pass.

## Follow-up (tracked in #984)

- **Phase 2** — direct tests for the highest-risk untested logic (security
  static-file handlers, OIDC username-conflict resolution, tag loading, download
  archive creation, Squonk job request validation).
- **Phase 3** — baseline breadth for the zero-coverage apps.

Each phase will ratchet `fail_under` upward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
