### PR TITLE
test(984): highest-risk untested logic (phase 2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ omit = [
 # slipping below where it stands today. Raise this as new tests land (see
 # issue #984's phased plan). pytest exits non-zero when the total drops below
 # this floor, which fails the CI 'Unit tests (pytest)' step.
-fail_under = 35
+fail_under = 38
 
 [tool.coverage.html]
 directory = "htmlcov"

--- a/viewer/tests/test_auth_backend.py
+++ b/viewer/tests/test_auth_backend.py
@@ -1,0 +1,179 @@
+"""Tests for the Keycloak OIDC authentication backend (issue #984, phase 2).
+
+``fragalysis.auth.KeycloakOIDCAuthenticationBackend`` carries the m2ms-2116
+username-conflict recovery and the 403->PermissionDenied translation. These are
+security-sensitive login paths with no previous tests, so the username
+resolution, new-user creation, the 403 translation and the stale-account rename
+recovery are pinned here.
+
+The backend instantiates without contacting Keycloak (its __init__ only reads
+settings), so we drive its methods directly. The single external seam - the
+provider's userinfo HTTP call inside ``super().get_or_create_user`` - is patched.
+"""
+# pylint: disable=protected-access,redefined-outer-name
+from unittest import mock
+
+import pytest
+from django.db import IntegrityError
+from mozilla_django_oidc.auth import OIDCAuthenticationBackend
+from requests.exceptions import HTTPError
+from rest_framework.exceptions import PermissionDenied
+
+from fragalysis.auth import (
+    _CONFLICT_PREFIX,
+    _DUPLICATE_KEY_MESSAGE,
+    KeycloakOIDCAuthenticationBackend,
+    _username_from_claims,
+)
+
+
+@pytest.fixture
+def backend():
+    return KeycloakOIDCAuthenticationBackend()
+
+
+def _claims(username="alice", email="alice@example.com", **extra):
+    """Build a claims dict keyed on the configured username field ('fedid')."""
+    claims = {"fedid": username, "email": email}
+    claims.update(extra)
+    return claims
+
+
+def test_username_from_primary_claim(settings):
+    settings.OIDC_CLAIM_USERNAME_FIELD = "fedid"
+    assert _username_from_claims({"fedid": "alice"}) == "alice"
+
+
+def test_username_falls_back_to_preferred_username(settings):
+    """When the configured field is absent, 'preferred_username' is used."""
+    settings.OIDC_CLAIM_USERNAME_FIELD = "fedid"
+    assert _username_from_claims({"preferred_username": "bob"}) == "bob"
+
+
+def test_username_none_when_no_claim(settings):
+    settings.OIDC_CLAIM_USERNAME_FIELD = "fedid"
+    assert _username_from_claims({"email": "x@example.com"}) is None
+
+
+def test_verify_claims_rejects_when_no_username(backend, settings):
+    settings.OIDC_CLAIM_USERNAME_FIELD = "fedid"
+    assert backend.verify_claims({"email": "x@example.com"}) is False
+    assert backend.verify_claims({"fedid": "alice", "email": "x@example.com"}) is True
+
+
+@pytest.mark.django_db
+def test_create_user_sets_username_and_profile_from_claims(backend, settings):
+    """A new login is created with the claim username, email and names."""
+    settings.OIDC_CLAIM_USERNAME_FIELD = "fedid"
+    claims = _claims(
+        username="alice",
+        email="alice@example.com",
+        given_name="Alice",
+        family_name="Smith",
+    )
+
+    user = backend.create_user(claims)
+
+    user.refresh_from_db()
+    assert user.username == "alice"
+    assert user.email == "alice@example.com"
+    assert user.first_name == "Alice"
+    assert user.last_name == "Smith"
+
+
+def test_get_or_create_user_translates_403_to_permission_denied(backend, monkeypatch):
+    """A 403 from the OIDC provider becomes a clean DRF PermissionDenied (not 500)."""
+    response = mock.Mock(status_code=403)
+
+    def _raise_403(*_args, **_kwargs):
+        raise HTTPError(response=response)
+
+    monkeypatch.setattr(OIDCAuthenticationBackend, "get_or_create_user", _raise_403)
+
+    with pytest.raises(PermissionDenied):
+        backend.get_or_create_user("access", "id", {})
+
+
+def test_get_or_create_user_reraises_other_http_errors(backend, monkeypatch):
+    """A non-403 HTTPError (e.g. 401) is re-raised for the library to handle."""
+    response = mock.Mock(status_code=401)
+
+    def _raise_401(*_args, **_kwargs):
+        raise HTTPError(response=response)
+
+    monkeypatch.setattr(OIDCAuthenticationBackend, "get_or_create_user", _raise_401)
+
+    with pytest.raises(HTTPError):
+        backend.get_or_create_user("access", "id", {})
+
+
+@pytest.mark.django_db
+def test_update_user_happy_path(backend, make_user, settings):
+    """With no username clash the user is updated in place."""
+    settings.OIDC_CLAIM_USERNAME_FIELD = "fedid"
+    user = make_user("alice", email="old@example.com")
+
+    result = backend.update_user(
+        user, _claims(username="alice", email="new@example.com", given_name="Alice")
+    )
+
+    result.refresh_from_db()
+    assert result.username == "alice"
+    assert result.email == "new@example.com"
+    assert result.first_name == "Alice"
+
+
+@pytest.mark.django_db
+def test_update_user_frees_username_from_stale_account(backend, make_user, settings):
+    """An email-matched login claiming a taken username renames the stale row.
+
+    The user keeps the username they expect; the colliding (stale) account is
+    moved aside with the _CONFLICT_PREFIX so the login still succeeds.
+    """
+    settings.OIDC_CLAIM_USERNAME_FIELD = "fedid"
+    stale = make_user("bob", email="stale@example.com")
+    # The real (email-matched) account that should own 'bob'.
+    incoming = make_user("bob-temp", email="bob@example.com")
+
+    result = backend.update_user(
+        incoming, _claims(username="bob", email="bob@example.com")
+    )
+
+    result.refresh_from_db()
+    stale.refresh_from_db()
+    assert result.pk == incoming.pk
+    assert result.username == "bob"
+    assert stale.username == f"{_CONFLICT_PREFIX}bob"
+
+
+@pytest.mark.django_db
+def test_save_conflict_unrecoverable_integrity_error_becomes_403(
+    backend, make_user, monkeypatch
+):
+    """A non-collision IntegrityError fails the login as 403, not 500."""
+    user = make_user("carol")
+
+    def _raise_other(*_args, **_kwargs):
+        raise IntegrityError("null value in column violates not-null constraint")
+
+    monkeypatch.setattr(user, "save", _raise_other)
+
+    with pytest.raises(PermissionDenied):
+        backend._save_resolving_username_conflict(user, "carol")
+
+
+@pytest.mark.django_db
+def test_save_conflict_without_conflicting_row_becomes_403(
+    backend, make_user, monkeypatch
+):
+    """The collision text is present but no other row holds the name: 403, not 500."""
+    user = make_user("dave")
+
+    def _raise_duplicate(*_args, **_kwargs):
+        raise IntegrityError(_DUPLICATE_KEY_MESSAGE)
+
+    monkeypatch.setattr(user, "save", _raise_duplicate)
+
+    # No other User owns 'unique-name', so recovery is impossible.
+    with pytest.raises(PermissionDenied):
+        backend._save_resolving_username_conflict(user, "unique-name")

--- a/viewer/tests/test_security_static_files.py
+++ b/viewer/tests/test_security_static_files.py
@@ -1,0 +1,151 @@
+"""Tests for the media-download authorisation barrier (issue #984, phase 2).
+
+``api.security.ISPyBSafeStaticFiles`` (used by the ``/metadata/``, ``/bound/``,
+``/maps/`` and ``/targets/`` downloads) is the access-control gate for static
+file serving: ``get_response`` only resolves a file the requesting user is
+allowed to see, otherwise it raises ``Http404``. A bug here leaks files, so the
+member / non-member / public / anonymous paths are pinned here.
+
+``ISPyBSafeStaticFiles2`` (used by ``/pdbs/``, ``/target_loader_data/`` and
+``/computed_set_data/``) deliberately does *not* re-query the database - it only
+builds the Nginx ``X-Accel-Redirect`` path - so its test asserts that path
+construction rather than access control.
+
+Access control is driven through the Django membership path
+(``TA_AUTH_SERVICE`` unset, ``Project.user_id`` membership) - the same seam the
+existing ``test_security.py`` uses.
+"""
+# The static-file mixins are configured by assigning attributes at call sites
+# (see media_serve.views), so mypy cannot see them as declared members.
+# mypy: disable-error-code="attr-defined"
+# pylint: disable=redefined-outer-name
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.http import Http404
+from django.test import RequestFactory
+
+from api.security import ISPyBSafeStaticFiles, ISPyBSafeStaticFiles2
+from viewer.models import Target
+
+# The stored FileField value and the basename Nginx should be handed.
+_METADATA_PATH = "metadata/Mpro_meta.csv"
+_METADATA_NAME = "Mpro_meta.csv"
+
+
+@pytest.fixture
+def target_with_metadata(make_project, make_target):
+    """Factory: a Target carrying a metadata file, in a (named) project.
+
+    Returns ``(target, project)`` so the test can grant/withhold membership.
+    """
+
+    def _make(title="proposal-meta", members=(), open_to_public=False):
+        project = make_project(title, members=members, open_to_public=open_to_public)
+        target = make_target(project)
+        target.metadata = _METADATA_PATH
+        target.save()
+        return target, project
+
+    return _make
+
+
+def _metadata_handler(user):
+    """An ISPyBSafeStaticFiles wired up exactly as ``metadata_download`` wires it."""
+    handler = ISPyBSafeStaticFiles()
+    handler.model = Target
+    request = RequestFactory().get("/metadata/" + _METADATA_NAME)
+    request.user = user
+    handler.request = request
+    handler.permission_string = "project"
+    handler.field_name = "metadata"
+    handler.content_type = "application/x-pilot"
+    handler.prefix = "/metadata/"
+    handler.input_string = _METADATA_NAME
+    return handler
+
+
+@pytest.mark.django_db
+def test_member_is_served_the_file(target_with_metadata, make_user, settings):
+    """A project member gets an X-Accel-Redirect to the resolved file."""
+    settings.TA_AUTH_SERVICE = ""
+    user = make_user("member")
+    target_with_metadata(members=[user])
+
+    response = _metadata_handler(user).get_response()
+
+    assert response.status_code == 200
+    assert response["X-Accel-Redirect"] == "/metadata/" + _METADATA_NAME
+    assert response["Content-Type"] == "application/x-pilot"
+    assert _METADATA_NAME in response["Content-Disposition"]
+
+
+@pytest.mark.django_db
+def test_non_member_is_denied(target_with_metadata, make_user, settings):
+    """A user with no membership of the target's project gets a 404, not the file."""
+    settings.TA_AUTH_SERVICE = ""
+    target_with_metadata(members=[])  # owned by nobody
+    outsider = make_user("outsider")
+
+    with pytest.raises(Http404):
+        _metadata_handler(outsider).get_response()
+
+
+@pytest.mark.django_db
+def test_public_project_is_served_to_non_member(
+    target_with_metadata, make_user, settings
+):
+    """An open_to_public project's file is served even without membership."""
+    settings.TA_AUTH_SERVICE = ""
+    settings.PUBLIC_TAS_LIST = []
+    target_with_metadata(open_to_public=True, members=[])
+    anyone = make_user("anyone")
+
+    response = _metadata_handler(anyone).get_response()
+
+    assert response.status_code == 200
+    assert response["X-Accel-Redirect"] == "/metadata/" + _METADATA_NAME
+
+
+@pytest.mark.django_db
+def test_anonymous_user_denied_private_file(target_with_metadata, settings):
+    """The ``user.pk is None`` path: an anonymous user gets no private file."""
+    settings.TA_AUTH_SERVICE = ""
+    target_with_metadata(open_to_public=False, members=[])
+
+    with pytest.raises(Http404):
+        _metadata_handler(AnonymousUser()).get_response()
+
+
+@pytest.mark.django_db
+def test_anonymous_user_served_public_file(target_with_metadata, settings):
+    """An anonymous user may still read a public project's file."""
+    settings.TA_AUTH_SERVICE = ""
+    settings.PUBLIC_TAS_LIST = []
+    target_with_metadata(open_to_public=True, members=[])
+
+    response = _metadata_handler(AnonymousUser()).get_response()
+
+    assert response.status_code == 200
+    assert response["X-Accel-Redirect"] == "/metadata/" + _METADATA_NAME
+
+
+def test_static_files2_builds_nginx_redirect_path():
+    """ISPyBSafeStaticFiles2 maps prefix + input to an absolute X-Accel-Redirect.
+
+    It does no DB lookup, so no access check happens here - it is the path
+    builder for the loader-data downloads.
+    """
+    handler = ISPyBSafeStaticFiles2()
+    handler.content_type = "application/x-pilot"
+    handler.prefix = "/target_loader_data/"
+    handler.input_string = "Mpro/aligned/Mpro-x0001/Mpro-x0001_apo.pdb"
+
+    response = handler.get_response()
+
+    assert response.status_code == 200
+    assert (
+        response["X-Accel-Redirect"]
+        == "/target_loader_data/Mpro/aligned/Mpro-x0001/Mpro-x0001_apo.pdb"
+    )
+    assert response["Content-Type"] == "application/x-pilot"
+    assert handler.input_string in response["Content-Disposition"]

--- a/viewer/tests/test_squonk_job_request.py
+++ b/viewer/tests/test_squonk_job_request.py
@@ -1,0 +1,75 @@
+"""Tests for the Squonk2 job-request guards (issue #984, phase 2).
+
+``viewer.squonk_job_request.create_squonk_job`` validates the snapshot's file
+transfers and the Squonk2 project before queueing a job. These guards each
+raise ``ValueError`` rather than letting a bad request through; they previously
+had no tests. We drive the early validation branches with a stub request and
+the shared ``mock_squonk_agent`` fixture, so no live Data-Manager API is
+contacted. The success path (which queues a real DM job) stays with the
+integration suite.
+"""
+# pylint: disable=redefined-outer-name
+from types import SimpleNamespace
+
+import pytest
+
+from viewer import squonk_job_request
+from viewer.models import JobFileTransfer, Snapshot
+from viewer.squonk2_agent import Squonk2AgentRv
+
+
+@pytest.fixture
+def job_request():
+    """Factory for a minimal DRF-like request create_squonk_job understands."""
+
+    def _make(user, snapshot_id):
+        return SimpleNamespace(
+            session={"oidc_access_token": "token"},
+            user=user,
+            data={
+                "access": "proposal-1",
+                "target": 1,
+                "snapshot": snapshot_id,
+                "session_project": 1,
+                "squonk_job_name": "test-job",
+                "squonk_job_spec": "{}",
+            },
+        )
+
+    return _make
+
+
+@pytest.mark.django_db
+def test_missing_file_transfer_raises(job_request, make_user):
+    """A snapshot with no JobFileTransfer cannot run a job."""
+    request = job_request(make_user("alice"), snapshot_id=999999)
+
+    with pytest.raises(ValueError, match="No JobFileTransfer object"):
+        squonk_job_request.create_squonk_job(request)
+
+
+@pytest.mark.django_db
+def test_incomplete_transfer_raises(job_request, make_user):
+    """A file transfer that has not reached SUCCESS blocks the job."""
+    snapshot = Snapshot.objects.create(title="snap", data="{}")
+    JobFileTransfer.objects.create(
+        snapshot=snapshot, transfer_status=JobFileTransfer.STARTED
+    )
+    request = job_request(make_user("bob"), snapshot_id=snapshot.id)
+
+    with pytest.raises(ValueError, match="Job Transfer not complete"):
+        squonk_job_request.create_squonk_job(request)
+
+
+@pytest.mark.django_db
+def test_ensure_project_failure_raises(job_request, make_user, mock_squonk_agent):
+    """If the agent cannot get/create a Squonk2 Project, the job is refused."""
+    snapshot = Snapshot.objects.create(title="snap", data="{}")
+    JobFileTransfer.objects.create(
+        snapshot=snapshot, transfer_status=JobFileTransfer.SUCCESS
+    )
+    mock_squonk_agent(ensure_project=Squonk2AgentRv(success=False, msg="no project"))
+    request = job_request(make_user("carol"), snapshot_id=snapshot.id)
+
+    with pytest.raises(ValueError, match="failed to get/create a Squonk2 Project"):
+        squonk_job_request.create_squonk_job(request)

--- a/viewer/tests/test_tags_loader.py
+++ b/viewer/tests/test_tags_loader.py
@@ -1,0 +1,135 @@
+"""Tests for the tag-file ingestion helpers (issue #984, phase 2).
+
+``viewer.tags.load_tags_from_file`` rewrites tags, poses and quality statuses
+from an uploaded metadata file and previously had no tests. The full happy path
+needs a completely loaded target (experiments, canon sites, poses) and is best
+covered by the loader integration tests; here we pin the pure parsing helpers,
+the boolean-column sanitiser (which must flag bad values rather than pass them
+silently) and the "not a valid file" guard - the cheap, high-value parts that
+guard against silent data corruption.
+"""
+import pandas as pd
+import pytest
+
+from viewer.tags import (
+    get_ann_tag,
+    get_tag_cols,
+    load_tags_from_file,
+    sanitize_boolean_column,
+    strip_alias,
+    strip_catname,
+    validate_aliases,
+)
+
+
+@pytest.mark.parametrize(
+    "value", ["true", "1", "t", "y", "yes", "True", "TRUE", True, 1]
+)
+def test_sanitize_boolean_true_representations(value):
+    column = pd.Series([value], name="flag")
+    result, errors = sanitize_boolean_column(column, [])
+    assert result.tolist() == [True]
+    assert errors == []
+
+
+@pytest.mark.parametrize("value", ["false", "0", "n", "no", "False", False, 0, ""])
+def test_sanitize_boolean_false_representations(value):
+    column = pd.Series([value], name="flag")
+    result, errors = sanitize_boolean_column(column, [])
+    assert result.tolist() == [False]
+    assert errors == []
+
+
+def test_sanitize_boolean_invalid_value_is_flagged_not_swallowed():
+    """An unrecognised value records an error and is passed through unchanged."""
+    column = pd.Series(["maybe"], name="flag")
+    result, errors = sanitize_boolean_column(column, [])
+    assert result.tolist() == ["maybe"]
+    assert errors == ["Invalid boolean value 'maybe' in column 'flag'"]
+
+
+def test_strip_catname_splits_category_and_name():
+    assert strip_catname("[Other] P2 Wave 1") == ("Other", "P2 Wave 1")
+
+
+def test_strip_catname_handles_brackets_in_name():
+    assert strip_catname("[Series] foo [bar]") == ("Series", "foo [bar]")
+
+
+def test_strip_alias_without_prefix_returns_value():
+    assert strip_alias("plain") == "plain"
+
+
+def test_strip_alias_with_prefix_returns_alias_part():
+    assert strip_alias("x - alias") == "alias"
+
+
+def test_get_tag_cols_selects_only_curated_category_columns():
+    columns = [
+        "Long code",
+        "[Series] one",
+        "[Forum] two",
+        "[Other] three",
+        "[CanonSites] auto",  # not a curated category - excluded
+    ]
+    assert get_tag_cols(columns) == ["[Series] one", "[Forum] two", "[Other] three"]
+
+
+def test_get_ann_tag_is_stable_md5():
+    assert get_ann_tag("Main status") == get_ann_tag("Main status")
+    assert get_ann_tag("a") != get_ann_tag("b")
+
+
+def _alias_frame(rows):
+    """Build a DataFrame with the upload-name/alias columns validate_aliases needs."""
+    from viewer.tags import TAG_CATEGORIES
+
+    columns: dict[str, list] = {}
+    for cat in TAG_CATEGORIES:
+        columns[f"{cat} upload name"] = []
+        columns[f"{cat} alias"] = []
+    df = pd.DataFrame(columns=list(columns.keys()))
+    for row in rows:
+        df.loc[len(df)] = row
+    return df
+
+
+def test_validate_aliases_accepts_consistent_pairs():
+    df = _alias_frame([])
+    # One upload name with a single, consistent alias in the first category.
+    df.loc[0] = [""] * len(df.columns)
+    df.loc[0, "ConformerSites upload name"] = "up1"
+    df.loc[0, "ConformerSites alias"] = "alias1"
+
+    result, errors = validate_aliases(df)
+
+    assert errors == []
+    assert ("up1", "alias1") in result
+
+
+def test_validate_aliases_flags_inconsistent_alias():
+    df = _alias_frame([])
+    for idx in (0, 1):
+        df.loc[idx] = [""] * len(df.columns)
+        df.loc[idx, "ConformerSites upload name"] = "up1"
+    # Same upload name, two different aliases -> inconsistent.
+    df.loc[0, "ConformerSites alias"] = "alias1"
+    df.loc[1, "ConformerSites alias"] = "alias2"
+
+    _, errors = validate_aliases(df)
+
+    assert any("Inconsistent aliases for tag 'up1'" in e for e in errors)
+
+
+@pytest.mark.django_db
+def test_load_tags_from_file_rejects_non_csv_xlsx(make_project, make_target, tmp_path):
+    """A file that is neither CSV nor XLSX yields an error, not a silent pass."""
+    target = make_target(make_project("proposal-tags"))
+    bad_file = tmp_path / "garbage.bin"
+    # Bytes that are invalid UTF-8 (so read_csv raises UnicodeDecodeError) and
+    # not a valid workbook (so read_excel raises ValueError).
+    bad_file.write_bytes(b"\xff\xfe\x00\x01not a spreadsheet")
+
+    errors = load_tags_from_file(str(bad_file), target)
+
+    assert errors == [f"{bad_file} is not a valid CSV or XLSX file"]


### PR DESCRIPTION
Part of #984 — **Phase 2** of the staged test-coverage plan: direct tests for
the highest-risk untested logic (security, auth, data mutation), built on the
shared mock fixtures added in Phase 1 (#985). No production code changes.

Coverage rises **36.59% → 38.32%**; the `fail_under` ratchet is raised
**35 → 38**.

## What this adds

- **`api/security.py` static-file handlers** —
  `viewer/tests/test_security_static_files.py`. The media-download
  authorisation barrier: a member is served the file, a non-member and a
  private-file anonymous request get `Http404`, an `open_to_public` project is
  served to non-members and anonymous users (the `user.pk is None` path), and
  `ISPyBSafeStaticFiles2` builds the correct Nginx `X-Accel-Redirect` path.
- **`fragalysis/auth.py` OIDC backend** — `viewer/tests/test_auth_backend.py`.
  Username resolution + `preferred_username` fallback, new-user creation from
  claims, the **403 → `PermissionDenied`** translation (and non-403 re-raise),
  and the m2ms-2116 **stale-account rename / `IntegrityError` recovery**
  (successful rename, plus the two unrecoverable cases that must become a clean
  403, not a 500).
- **`viewer/tags.py`** — `viewer/tests/test_tags_loader.py`.
  `sanitize_boolean_column` (recognised true/false forms, and an unrecognised
  value is **flagged, not silently swallowed**), the parsing helpers
  (`strip_catname`, `strip_alias`, `get_tag_cols`, `validate_aliases`,
  `get_ann_tag`), and the "not a valid CSV/XLSX" guard.
- **`viewer/squonk_job_request.py`** —
  `viewer/tests/test_squonk_job_request.py`. The `create_squonk_job` guards:
  missing file transfer, incomplete transfer, and `ensure_project` failure —
  each must raise `ValueError`, driven through the `mock_squonk_agent` fixture
  (no live Data-Manager API).

47 new tests.

## Verification

- `./run-unit-tests.sh` — **182 passed, 1 skipped, 1 deselected**; gate reports
  *"Required test coverage of 38.0% reached. Total coverage: 38.32%"*.
- `pre-commit run --files …` on all new files — clean.

## Deferred (tracked in #984)

- **`viewer/download_structures.py` `create_download()`** archive assembly —
  needs a fully loaded target with on-disk files; best added alongside the
  loader fixtures rather than hand-built here.
- **Phase 3** — baseline breadth for the remaining zero-coverage apps, ratcheting
  `fail_under` a final time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
