### PR TITLE
test(984): baseline breadth for zero-coverage apps (phase 3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ omit = [
 # slipping below where it stands today. Raise this as new tests land (see
 # issue #984's phased plan). pytest exits non-zero when the total drops below
 # this floor, which fails the CI 'Unit tests (pytest)' step.
-fail_under = 38
+fail_under = 39
 
 [tool.coverage.html]
 directory = "htmlcov"

--- a/viewer/tests/test_api_utils.py
+++ b/viewer/tests/test_api_utils.py
@@ -1,0 +1,47 @@
+"""Tests for the small cross-cutting helpers in ``api.utils`` (issue #984, phase 3).
+
+``validate_tas`` is the Target-Access-String gate used wherever a TAS is
+accepted, and ``deployment_mode_is_production`` switches strict behaviour on -
+both are high-traffic and previously untested.
+
+Note: ``api.utils.TAS_REGEX_RE`` is compiled from ``settings.TAS_REGEX`` at
+import time, so these tests use the default pattern (``^(lb|sw)\\d{5}-\\d+$``)
+rather than overriding the setting (which would not recompile the regex).
+"""
+import pytest
+
+from api.utils import deployment_mode_is_production, validate_tas
+
+
+@pytest.mark.parametrize("tas", ["lb12345-1", "sw00000-99", "lb54321-123"])
+def test_validate_tas_accepts_well_formed(tas):
+    valid, error = validate_tas(tas)
+    assert valid is True
+    assert error is None
+
+
+@pytest.mark.parametrize(
+    "tas",
+    [
+        "",  # empty
+        "xx12345-1",  # wrong prefix
+        "lb1234-1",  # too few digits
+        "lb12345",  # missing visit
+        "lb12345-",  # missing visit number
+        " lb12345-1",  # leading space
+    ],
+)
+def test_validate_tas_rejects_malformed(tas, settings):
+    valid, error = validate_tas(tas)
+    assert valid is False
+    assert error == settings.TAS_REGEX_ERROR_MSG
+
+
+def test_deployment_mode_is_production_true(settings):
+    settings.DEPLOYMENT_MODE = "PRODUCTION"
+    assert deployment_mode_is_production() is True
+
+
+def test_deployment_mode_is_production_false(settings):
+    settings.DEPLOYMENT_MODE = "DEVELOPMENT"
+    assert deployment_mode_is_production() is False

--- a/viewer/tests/test_infections.py
+++ b/viewer/tests/test_infections.py
@@ -1,0 +1,40 @@
+"""Tests for the infection (forced-error) catalogue (issue #984, phase 3).
+
+``api.infections`` parses the ``INFECTIONS`` env-driven setting into a set of
+recognised infection names and gates them behind the deployment mode -
+infections must never fire in production. These are pure, DB-free helpers.
+"""
+from api import infections
+from api.infections import INFECTION_STRUCTURE_DOWNLOAD, have_infection
+
+
+def test_empty_setting_yields_no_infections(settings):
+    settings.INFECTIONS = ""
+    assert infections._get_infections() == set()  # pylint: disable=protected-access
+
+
+def test_known_infections_are_parsed(settings):
+    settings.INFECTIONS = INFECTION_STRUCTURE_DOWNLOAD
+    assert infections._get_infections() == {  # pylint: disable=protected-access
+        INFECTION_STRUCTURE_DOWNLOAD
+    }
+
+
+def test_unknown_infection_is_filtered_out(settings):
+    settings.INFECTIONS = f"{INFECTION_STRUCTURE_DOWNLOAD},not-a-real-infection"
+    assert infections._get_infections() == {  # pylint: disable=protected-access
+        INFECTION_STRUCTURE_DOWNLOAD
+    }
+
+
+def test_have_infection_true_when_present_and_not_production(settings):
+    settings.DEPLOYMENT_MODE = "DEVELOPMENT"
+    settings.INFECTIONS = INFECTION_STRUCTURE_DOWNLOAD
+    assert have_infection(INFECTION_STRUCTURE_DOWNLOAD) is True
+
+
+def test_have_infection_always_false_in_production(settings):
+    """Even if requested, an infection never fires in production mode."""
+    settings.DEPLOYMENT_MODE = "PRODUCTION"
+    settings.INFECTIONS = INFECTION_STRUCTURE_DOWNLOAD
+    assert have_infection(INFECTION_STRUCTURE_DOWNLOAD) is False

--- a/viewer/tests/test_media_serve_map_download.py
+++ b/viewer/tests/test_media_serve_map_download.py
@@ -1,0 +1,48 @@
+"""Tests for map_download's extension->field resolution (issue #984, phase 3).
+
+``media_serve.views.map_download`` picks which SiteObservation file field to
+serve by substring-parsing the requested file name (``2fofc``/``fofc``/``event``
+=> ``sigmaa_info``/``diff_info``/``event_info``). The parsing is fragile, so the
+field selection is pinned here. We patch ``get_response`` to capture the chosen
+field rather than hit the DB - the download authorisation itself is covered by
+test_security_static_files.py.
+"""
+# pylint: disable=redefined-outer-name
+import pytest
+from django.test import RequestFactory
+
+from api.security import ISPyBSafeStaticFiles
+from media_serve import views
+
+
+@pytest.fixture
+def captured_field(monkeypatch):
+    """Patch get_response to return the field_name map_download selected."""
+    monkeypatch.setattr(
+        ISPyBSafeStaticFiles, "get_response", lambda self: self.field_name
+    )
+
+    def _call(file_path):
+        request = RequestFactory().get("/maps/" + file_path)
+        return views.map_download(request, file_path)
+
+    return _call
+
+
+@pytest.mark.parametrize(
+    "file_path,expected_field",
+    [
+        ("Mpro-x0001_2fofc.map", "sigmaa_info"),
+        ("Mpro-x0001_fofc.map", "diff_info"),
+        ("Mpro-x0001_event.map", "event_info"),
+    ],
+)
+def test_map_download_selects_field_by_extension(
+    captured_field, file_path, expected_field
+):
+    assert captured_field(file_path) == expected_field
+
+
+def test_map_download_unknown_extension_selects_no_field(captured_field):
+    """A name with no recognised map extension resolves to no field (None)."""
+    assert captured_field("Mpro-x0001_apo.map") is None

--- a/viewer/tests/test_network_functions.py
+++ b/viewer/tests/test_network_functions.py
@@ -1,0 +1,54 @@
+"""Tests for the network graph ordering (issue #984, phase 3).
+
+``network.functions.order_structures`` re-shapes a flat ``{key: smiles}`` graph
+result into a nested depth/type/position dict, decorating each position as an
+ADD/DEL/LINK based on three decoration lists, and adding empty placeholders for
+decorations with no matching result. The key parsing (``key.split("_")``) is
+fragile, so the happy path and the "missing decoration" path are pinned here.
+A pure function - no Neo4j.
+"""
+import json
+
+from network.functions import order_structures
+
+
+def test_order_structures_nests_by_depth_type_position():
+    # key format is "position_depth_type".
+    results = {"pos1_3_ADDITION": ["C"], "pos2_3_ADDITION": ["CC"]}
+    decoration_list = [["pos1"], [], []]  # pos1 is an addition
+
+    out = json.loads(order_structures(results, decoration_list))
+
+    assert out["3"]["ADDITION"]["pos1"] == {
+        "smiles": ["C"],
+        "annotation": "ADD_DEC",
+    }
+    # pos2 is not in any decoration list -> BLANK.
+    assert out["3"]["ADDITION"]["pos2"]["annotation"] == "BLANK"
+
+
+def test_order_structures_annotates_each_decoration_type():
+    results = {
+        "a_1_T": ["C"],
+        "b_1_T": ["N"],
+        "c_1_T": ["O"],
+    }
+    decoration_list = [["a"], ["b"], ["c"]]  # add, del, link
+
+    out = json.loads(order_structures(results, decoration_list))
+
+    assert out["1"]["T"]["a"]["annotation"] == "ADD_DEC"
+    assert out["1"]["T"]["b"]["annotation"] == "DEL_DEC"
+    assert out["1"]["T"]["c"]["annotation"] == "LINK_DEC"
+
+
+def test_order_structures_adds_empty_for_missing_decorations():
+    """A decoration with no matching result gets an empty placeholder at depth -1."""
+    results: dict = {}  # nothing came back from the graph
+    decoration_list = [["addme"], ["delme"], ["linkme"]]
+
+    out = json.loads(order_structures(results, decoration_list))
+
+    assert out["-1"]["ADDITION"]["addme"] == {"smiles": [], "annotation": "ADD_MISS"}
+    assert out["-1"]["DELETION"]["delme"] == {"smiles": [], "annotation": "DEL_MISS"}
+    assert out["-1"]["LINKER"]["linkme"] == {"smiles": [], "annotation": "LINK_MISS"}

--- a/viewer/tests/test_scoring_managers.py
+++ b/viewer/tests/test_scoring_managers.py
@@ -1,0 +1,36 @@
+"""Tests for the scoring ``by_target`` managers (issue #984, phase 3).
+
+Each scoring model has a ``filter_manager.by_target()`` that prefetches the
+SiteObservation->experiment->experiment_upload->target chain and annotates the
+target via an ``F`` expression before filtering. These relation paths are easy
+to break silently, so this exercises each manager's query end-to-end (it must
+compile and run against the schema); an empty target is sufficient to catch a
+bad relation path, which raises rather than returning rows.
+"""
+import pytest
+
+from scoring.models import CmpdChoice, ScoreChoice, SiteObservationChoice, ViewScene
+
+
+@pytest.mark.django_db
+def test_score_choice_by_target_runs(make_project, make_target):
+    target = make_target(make_project("proposal-score"))
+    assert list(ScoreChoice.filter_manager.by_target(target)) == []
+
+
+@pytest.mark.django_db
+def test_site_observation_choice_by_target_runs(make_project, make_target):
+    target = make_target(make_project("proposal-sobs"))
+    assert list(SiteObservationChoice.filter_manager.by_target(target)) == []
+
+
+@pytest.mark.django_db
+def test_cmpd_choice_by_target_runs(make_project, make_target):
+    target = make_target(make_project("proposal-cmpd"))
+    assert list(CmpdChoice.filter_manager.by_target(target)) == []
+
+
+@pytest.mark.django_db
+def test_view_scene_by_target_runs(make_project, make_target):
+    target = make_target(make_project("proposal-view"))
+    assert list(ViewScene.filter_manager.by_target(target)) == []

--- a/viewer/tests/test_service_status_services.py
+++ b/viewer/tests/test_service_status_services.py
@@ -1,0 +1,86 @@
+"""Tests for service_status.utils.services enable/disable/toggle (issue #984, phase 3).
+
+``services()`` is the manual override that flips a Service row between
+NOT_CONFIGURED (disabled) and DEGRADED (enabled, pending first probe). The
+enable/disable/toggle branches (including a name in *both* lists) had no tests.
+ServiceState rows are seeded by the service_status migrations.
+"""
+# pylint: disable=redefined-outer-name
+import pytest
+
+from service_status.models import Service, ServiceState
+from service_status.utils import State, services
+
+
+def _make_service(name: str, state: State) -> Service:
+    return Service.objects.create(
+        service=name,
+        display_name=name,
+        last_state=ServiceState.objects.get(state=state),
+    )
+
+
+@pytest.mark.django_db
+def test_enable_promotes_not_configured_to_degraded():
+    _make_service("ispyb", State.NOT_CONFIGURED)
+
+    services(enable=["ispyb"])
+
+    assert Service.objects.get(service="ispyb").last_state_id == State.DEGRADED
+
+
+@pytest.mark.django_db
+def test_enable_leaves_already_active_service_untouched():
+    """Enabling an OK service must not clobber it back to DEGRADED."""
+    _make_service("ispyb", State.OK)
+
+    services(enable=["ispyb"])
+
+    assert Service.objects.get(service="ispyb").last_state_id == State.OK
+
+
+@pytest.mark.django_db
+def test_disable_sets_not_configured():
+    _make_service("ispyb", State.OK)
+
+    services(disable=["ispyb"])
+
+    assert Service.objects.get(service="ispyb").last_state_id == State.NOT_CONFIGURED
+
+
+@pytest.mark.django_db
+def test_toggle_when_in_both_lists_enables_a_disabled_service():
+    """A name in both enable and disable toggles from its current state."""
+    _make_service("ispyb", State.NOT_CONFIGURED)
+
+    services(enable=["ispyb"], disable=["ispyb"])
+
+    assert Service.objects.get(service="ispyb").last_state_id == State.DEGRADED
+
+
+@pytest.mark.django_db
+def test_toggle_when_in_both_lists_disables_an_enabled_service():
+    _make_service("ispyb", State.OK)
+
+    services(enable=["ispyb"], disable=["ispyb"])
+
+    assert Service.objects.get(service="ispyb").last_state_id == State.NOT_CONFIGURED
+
+
+@pytest.mark.django_db
+def test_unknown_service_is_skipped_without_error():
+    """An unknown service name is logged and skipped, not raised."""
+    # No Service rows exist; this must not raise.
+    services(enable=["does-not-exist"], disable=["also-missing"])
+
+    assert Service.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_none_arguments_are_treated_as_empty():
+    _make_service("ispyb", State.OK)
+
+    services(enable=None, disable=None)
+
+    # Nothing requested, so state is unchanged.
+    assert Service.objects.get(service="ispyb").last_state_id == State.OK


### PR DESCRIPTION
Fixes #984 — **Phase 3** (final) of the staged test-coverage plan: cheap,
mostly pure-function tests that lift the previously zero/near-zero apps off the
floor. Builds on Phase 1 (#985) and Phase 2 (#986). No production code changes.

Coverage rises **38.32% → 39.26%**; the `fail_under` ratchet is raised
**38 → 39**.

## What this adds

| App | File | Coverage |
|---|---|---|
| `api/infections.py` | `test_infections.py` — `_get_infections` parsing, unknown-name filtering, empty case, production guard | **100%** |
| `api/utils.py` | `test_api_utils.py` — `validate_tas` accept/reject, `deployment_mode_is_production` | helper-level |
| `network/functions.py` | `test_network_functions.py` — `order_structures` nesting, ADD/DEL/LINK decoration, missing-decoration placeholders | **100%** |
| `service_status/utils.py` | `test_service_status_services.py` — `services()` enable/disable/toggle state machine (both-lists toggle, unknown names, `None` args) | 70% |
| `media_serve/views.py` | `test_media_serve_map_download.py` — `map_download` extension→field resolution (`2fofc`/`fofc`/`event` + no-match), `get_response` patched off the DB | — |
| `scoring/managers.py` | `test_scoring_managers.py` — each `by_target()` query runs end-to-end (guards the prefetch/annotate relation paths) | **94%** |

34 new tests.

## Verification

- `./run-unit-tests.sh` — **216 passed, 1 skipped, 1 deselected**; gate reports
  *"Required test coverage of 39.0% reached. Total coverage: 39.26%"*.
- `pre-commit run --files …` on all new files — clean.

## Plan status (#984)

- **Phase 1** (#985, merged) — coverage gate + shared mock fixtures.
- **Phase 2** (#986, merged) — security/auth/data-mutation hotspots.
- **Phase 3** (this PR) — baseline breadth.

Two follow-ups deliberately left out of scope (noted so they are not lost):

- **`download_structures.create_download()`** archive assembly still needs a
  fully loaded target with on-disk files (the Phase-2 deferral) — best added
  alongside loader fixtures.
- While testing `scoring/managers.py` I noticed
  `SiteObservationAnnotationDataManager.get_queryset` instantiates
  `SiteObservationChoiceQueryset` (copy-paste) rather than
  `SiteObservationAnnotationQueryset`, so `by_target` there queries the wrong
  model. It is latent (only bites with data) and out of scope for this
  test-only PR; worth a small fix on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
