### PR TITLE
fix(988): SiteObservationAnnotation manager queried the wrong model

### DIFF
--- a/scoring/managers.py
+++ b/scoring/managers.py
@@ -126,7 +126,7 @@ class SiteObservationAnnotationQueryset(QuerySet):
 
 class SiteObservationAnnotationDataManager(Manager):
     def get_queryset(self):
-        return SiteObservationChoiceQueryset(self.model, using=self._db)
+        return SiteObservationAnnotationQueryset(self.model, using=self._db)
 
     def filter_qs(self):
         return self.get_queryset().filter_qs()

--- a/viewer/tests/test_scoring_annotation_manager.py
+++ b/viewer/tests/test_scoring_annotation_manager.py
@@ -1,0 +1,24 @@
+"""Regression test for the SiteObservationAnnotation manager (issue #988).
+
+``SiteObservationAnnotationDataManager.get_queryset`` previously instantiated
+``SiteObservationChoiceQueryset`` (a copy-paste), so
+``SiteObservationAnnotation.filter_manager.filter_qs()`` - used directly as the
+``SiteObservationAnnotationView`` queryset - built a query over the wrong model
+(``SiteObservationChoice``). This pins the manager to its own model.
+"""
+from scoring.models import SiteObservationAnnotation, SiteObservationChoice
+
+
+def test_annotation_filter_qs_uses_annotation_model():
+    """filter_qs() must query SiteObservationAnnotation, not SiteObservationChoice."""
+    assert (
+        SiteObservationAnnotation.filter_manager.filter_qs().model
+        is SiteObservationAnnotation
+    )
+
+
+def test_choice_filter_qs_still_uses_choice_model():
+    """Guard the sibling manager so the fix does not swap the wrong way."""
+    assert (
+        SiteObservationChoice.filter_manager.filter_qs().model is SiteObservationChoice
+    )


### PR DESCRIPTION
Fixes #988.

## The bug

`scoring/managers.py` `SiteObservationAnnotationDataManager.get_queryset()`
instantiated `SiteObservationChoiceQueryset` instead of
`SiteObservationAnnotationQueryset` (a copy-paste). Since `filter_qs()` resolves
its model via `apps.get_model(...)` *inside the queryset class*, the wrong class
made `SiteObservationAnnotation.filter_manager.filter_qs()` build a query over
**`SiteObservationChoice`**.

That manager call is used directly as the view queryset:

```python
# scoring/views.py
class SiteObservationAnnotationView(...):
    queryset = SiteObservationAnnotation.filter_manager.filter_qs()
    filterset_fields = ("site_observation", "annotation_type")
```

so the SiteObservationAnnotation endpoint operated on the wrong model, and its
`annotation_type` filter field does not exist on `SiteObservationChoice`.

## The fix

One line: return `SiteObservationAnnotationQueryset` from `get_queryset()`.

## Test (TDD)

`viewer/tests/test_scoring_annotation_manager.py` asserts the manager's
`filter_qs()` is bound to `SiteObservationAnnotation`, plus a guard that the
sibling `SiteObservationChoice` manager is unaffected. The first test fails
before the fix (resolves to `SiteObservationChoice`) and passes after.

## Verification

- `./run-unit-tests.sh` — **184 passed, 1 skipped, 1 deselected**; coverage gate green.
- `pre-commit run --files …` — clean.

Found while adding scoring-manager tests in #984 phase 3 (#987).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
