### PR TITLE
ci: bump docker build/login actions to node24 runtimes

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -123,7 +123,7 @@ jobs:
       # tests/test_settings.py.
       run: poetry run pytest
     - name: Docker build
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         tags: ${{ steps.vars.outputs.BE_NAMESPACE }}/fragalysis-backend:${{ env.GITHUB_REF_SLUG }}
@@ -133,7 +133,7 @@ jobs:
         # with "unknown blob".
         provenance: false
     - name: Display
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         tags: ${{ steps.vars.outputs.BE_NAMESPACE }}/fragalysis-backend:${{ env.GITHUB_REF_SLUG }}
@@ -157,7 +157,7 @@ jobs:
         cat scan.md >> $GITHUB_STEP_SUMMARY
     - name: Login to DockerHub
       if: steps.vars.outputs.push == 'true'
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-production.yaml
+++ b/.github/workflows/build-production.yaml
@@ -167,7 +167,7 @@ jobs:
       # tests/test_settings.py.
       run: poetry run pytest
     - name: Build
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         tags: |
@@ -180,7 +180,7 @@ jobs:
         provenance: false
     - name: Login to DockerHub
       if: steps.vars.outputs.push == 'true'
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -189,7 +189,7 @@ jobs:
       # tests/test_settings.py.
       run: poetry run pytest
     - name: Docker build
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         tags: ${{ steps.vars.outputs.BE_NAMESPACE }}/fragalysis-backend:${{ steps.vars.outputs.tag }}
@@ -200,7 +200,7 @@ jobs:
         provenance: false
     - name: Login to DockerHub
       if: steps.vars.outputs.push == 'true'
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## What

Bump the Docker GitHub Actions to the majors that ship a **node24** runtime:

| Action | Before | After |
|---|---|---|
| `docker/build-push-action` | `@v6` | `@v7` |
| `docker/login-action` | `@v3` | `@v4` |

Applied across `build-dev.yaml`, `build-staging.yaml`, and `build-production.yaml`.

## Why

The `build` jobs emit:

> `Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: docker/build-push-action@v6, docker/login-action@v3.`

Node 20 is [deprecated on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). The v7/v4 majors run natively on node24, clearing the warning.

## Notes

- Verified both new majors declare `using: 'node24'`.
- The only behavioural change in build-push-action v7 is removal of the `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs — neither is used in this repo.
- `actions/upload-artifact@v4` (in `build-docs.yaml`) is still node20 but was not in the warning and has no newer major yet, so it is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
