### PR TITLE
test(991): pure-function coverage sweep (phase 4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ omit = [
 # slipping below where it stands today. Raise this as new tests land (see
 # issue #984's phased plan). pytest exits non-zero when the total drops below
 # this floor, which fails the CI 'Unit tests (pytest)' step.
-fail_under = 39
+fail_under = 40
 
 [tool.coverage.html]
 directory = "htmlcov"

--- a/viewer/tests/test_api_utils_pure.py
+++ b/viewer/tests/test_api_utils_pure.py
@@ -1,0 +1,63 @@
+"""Pure / RDKit-only tests for helpers in ``api.utils`` (issue #991).
+
+These complement ``test_api_utils.py`` (which covers ``validate_tas`` and
+``deployment_mode_is_production``) with the request-parameter parsers
+(``parse_bool``, ``parse_vectors``) and the geometry helpers (``calc_bounds``,
+``calc_dims``). None need a database or network.
+
+(``_transparentsvg`` is deliberately not tested: it is dead code - defined but
+never called - and carries a latent ``str + bytes`` bug, so exercising it would
+require fixing unrelated code.)
+"""
+import pytest
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+from api.utils import calc_bounds, calc_dims, parse_bool, parse_vectors
+
+
+@pytest.mark.parametrize("value", ["yes", "true", "t", "y", "1", "TRUE", "Yes"])
+def test_parse_bool_true(value):
+    assert parse_bool(value) is True
+
+
+@pytest.mark.parametrize("value", ["no", "false", "f", "n", "0", "FALSE", "No"])
+def test_parse_bool_false(value):
+    assert parse_bool(value) is False
+
+
+@pytest.mark.parametrize("value", ["", "maybe", "2", "yep"])
+def test_parse_bool_unparsable_raises(value):
+    with pytest.raises(ValueError, match="not parsable"):
+        parse_bool(value)
+
+
+def test_parse_vectors():
+    assert parse_vectors("1,2,3") == [1, 2, 3]
+
+
+def test_parse_vectors_single():
+    assert parse_vectors("42") == [42]
+
+
+@pytest.mark.parametrize("value", ["1,a,3", "1,,3", ""])
+def test_parse_vectors_malformed_raises(value):
+    with pytest.raises(ValueError):
+        parse_vectors(value)
+
+
+def test_calc_dims():
+    """Dimensions are simply the spans of the X and Y bounds."""
+    assert calc_dims([0, 3], [-1, 4]) == (3, 5)
+
+
+def test_calc_bounds_from_conformer():
+    """Bounds enclose every atom's 2D coordinates."""
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    AllChem.Compute2DCoords(mol)
+    conformer = mol.GetConformer()
+    x, y = calc_bounds(conformer)
+    # Bounds are [min, max]; min must be <= max and the spans positive.
+    assert x[0] <= x[1]
+    assert y[0] <= y[1]
+    assert calc_dims(x, y)[0] > 0

--- a/viewer/tests/test_assay_data.py
+++ b/viewer/tests/test_assay_data.py
@@ -1,0 +1,94 @@
+"""Tests for the pure cell parsers in ``viewer.assay_data`` (issue #991).
+
+``process_float_value`` / ``process_int_value`` parse a single spreadsheet cell
+into a ``(raw, modifier, value, parsing_error, error_msg)`` 5-tuple, recognising
+the ``<``, ``>``, ``<=``, ``>=`` modifier prefixes and flagging unparseable
+cells. ``process_text_value`` and ``get_unit`` are likewise pure. The DataFrame
+/ model-backed wrappers (``process_float`` etc.) need ResultValue* rows and are
+deferred per the issue.
+"""
+import math
+
+import pytest
+
+from viewer.assay_data import (
+    get_unit,
+    process_float_value,
+    process_int_value,
+    process_text_value,
+)
+
+
+@pytest.mark.parametrize(
+    "value,modifier,parsed",
+    [
+        ("5.0", None, "5.0"),
+        ("<=5.0", "<=", "5.0"),
+        (">=5.0", ">=", "5.0"),
+        ("<5.0", "<", "5.0"),
+        (">5.0", ">", "5.0"),
+        (".5", None, ".5"),
+        ("-3.2", None, "-3.2"),
+    ],
+)
+def test_process_float_value_parses(value, modifier, parsed):
+    raw, mod, val, parsing_error, error_msg = process_float_value(value)
+    assert raw == value
+    assert mod == modifier
+    assert val == parsed
+    assert parsing_error is False
+    assert math.isnan(error_msg)
+
+
+def test_process_float_value_unparsable():
+    raw, mod, val, parsing_error, error_msg = process_float_value("abc")
+    assert raw == "abc"
+    assert mod is None
+    assert val is None
+    assert parsing_error is True
+    assert error_msg == "Unable to parse abc to float"
+
+
+@pytest.mark.parametrize(
+    "value,modifier,parsed",
+    [
+        ("5", None, "5"),
+        ("<=5", "<=", "5"),
+        (">=5", ">=", "5"),
+        ("<5", "<", "5"),
+        (">5", ">", "5"),
+        ("-3", None, "-3"),
+    ],
+)
+def test_process_int_value_parses(value, modifier, parsed):
+    raw, mod, val, parsing_error, error_msg = process_int_value(value)
+    assert raw == value
+    assert mod == modifier
+    assert val == parsed
+    assert parsing_error is False
+    assert math.isnan(error_msg)
+
+
+def test_process_int_value_unparsable():
+    raw, mod, val, parsing_error, error_msg = process_int_value("abc")
+    assert raw == "abc"
+    assert mod is None
+    assert val is None
+    assert parsing_error is True
+    assert error_msg == "Unable to parse abc to int"
+
+
+def test_process_text_value():
+    assert process_text_value("hello") == ("hello", "hello", None)
+
+
+@pytest.mark.parametrize(
+    "title,expected",
+    [
+        ("IC50 (nM)", "nM"),
+        ("pIC50", ""),
+        ("Activity (uM) extra", "uM"),
+    ],
+)
+def test_get_unit(title, expected):
+    assert get_unit(title) == expected

--- a/viewer/tests/test_cache.py
+++ b/viewer/tests/test_cache.py
@@ -1,0 +1,73 @@
+"""Tests for the page-cache invalidation helpers in ``viewer.cache`` (#991).
+
+``clear_view_cache`` deletes only the keys matching the given view key_prefixes
+when the backend is Redis (SCAN/DELETE), and falls back to clearing the whole
+alias for backends without pattern delete. The Django cache backend is faked so
+the key-pattern logic is asserted without a real Redis.
+"""
+from unittest import mock
+
+from django.core.cache.backends.redis import RedisCache
+
+from viewer import cache as cache_module
+
+
+class _FakeCaches:
+    """Stands in for ``django.core.cache.caches`` - always hands out one cache."""
+
+    def __init__(self, backend):
+        self._backend = backend
+
+    def __getitem__(self, _alias):
+        return self._backend
+
+
+def _patch_caches(monkeypatch, backend):
+    monkeypatch.setattr(cache_module, "caches", _FakeCaches(backend))
+
+
+def test_clear_view_cache_no_prefixes_is_noop(monkeypatch):
+    backend = mock.Mock()
+    _patch_caches(monkeypatch, backend)
+
+    cache_module.clear_view_cache()
+
+    backend.clear.assert_not_called()
+
+
+def test_clear_view_cache_non_redis_clears_whole_alias(monkeypatch):
+    backend = mock.Mock()  # not a RedisCache instance
+    _patch_caches(monkeypatch, backend)
+
+    cache_module.clear_view_cache("alpha")
+
+    backend.clear.assert_called_once_with()
+
+
+def test_clear_view_cache_redis_scans_and_deletes(monkeypatch):
+    client = mock.Mock()
+    # Two keys returned per scan pattern.
+    client.scan_iter.return_value = ["k1", "k2"]
+
+    backend = mock.Mock(spec=RedisCache)
+    backend._cache.get_client.return_value = client  # pylint: disable=protected-access
+    _patch_caches(monkeypatch, backend)
+
+    cache_module.clear_view_cache("alpha")
+
+    # cache_page + cache_header patterns are both scanned for the prefix.
+    patterns = [c.kwargs["match"] for c in client.scan_iter.call_args_list]
+    assert "*.cache_page.alpha.*" in patterns
+    assert "*.cache_header.alpha.*" in patterns
+    # Every scanned key is deleted (2 keys x 2 patterns).
+    assert client.delete.call_count == 4
+    backend.clear.assert_not_called()
+
+
+def test_clear_all_view_caches_clears_alias(monkeypatch):
+    backend = mock.Mock()
+    _patch_caches(monkeypatch, backend)
+
+    cache_module.clear_all_view_caches()
+
+    backend.clear.assert_called_once_with()

--- a/viewer/tests/test_hypothesis_definitions.py
+++ b/viewer/tests/test_hypothesis_definitions.py
@@ -1,0 +1,57 @@
+"""Tests for the small lookup helpers in ``hypothesis.definitions`` (#991).
+
+``IntTypes`` and ``VectTypes`` are pure in-memory tables mapping external names
+to two-letter codes. The tests live under ``viewer/tests/`` because that is the
+suite's single ``testpaths`` root (as ``test_api_utils.py`` already does).
+"""
+import pytest
+
+from hypothesis.definitions import IntTypes, VectTypes
+
+
+def test_get_int_conv_known_version_and_name():
+    int_types = IntTypes()
+    assert int_types.get_int_conv("DE", "hbond") == "HB"
+    assert int_types.get_int_conv("PR", "vdW") == "VD"
+
+
+def test_get_int_conv_unknown_version_returns_none():
+    int_types = IntTypes()
+    assert int_types.get_int_conv("ZZ", "hbond") is None
+
+
+def test_get_int_conv_unknown_name_raises():
+    int_types = IntTypes()
+    with pytest.raises(KeyError):
+        int_types.get_int_conv("DE", "nonsense")
+
+
+def test_define_int_types_returns_defaults():
+    int_types = IntTypes()
+    ver_choices, default_ver, type_choices, default_type = int_types.define_int_types()
+    assert default_ver == "DE"
+    assert default_type == "UK"
+    assert ("DE", "Default") in ver_choices
+    assert ("HB", "H-bond") in type_choices
+
+
+@pytest.mark.parametrize(
+    "name,code",
+    [
+        ("additions", "AD"),
+        ("deletions", "DE"),
+        ("linkers", "LI"),
+        ("ring", "RI"),
+    ],
+)
+def test_translate_vect_types(name, code):
+    assert VectTypes().translate_vect_types(name) == code
+
+
+def test_translate_vect_types_unknown_raises():
+    with pytest.raises(KeyError):
+        VectTypes().translate_vect_types("unknown")
+
+
+def test_get_vect_types_returns_table():
+    assert ("AD", "Addition") in VectTypes().get_vect_types()

--- a/viewer/tests/test_logger_adapters.py
+++ b/viewer/tests/test_logger_adapters.py
@@ -1,0 +1,53 @@
+"""Tests for ``viewer.logger_adapters.TaskLoggerAdapter`` (issue #991).
+
+The adapter prefixes every log line with a compact task marker built from the
+``extra`` dict. Each optional key (task, marker, target, tas, username) adds a
+fragment; a blank username becomes ``u(|anon|)``. These are pure string
+transforms - no logging output is captured, only ``process()`` is exercised.
+"""
+import logging
+
+from viewer.logger_adapters import TaskLoggerAdapter
+
+
+def _adapter(extra):
+    return TaskLoggerAdapter(logging.getLogger("test"), extra)
+
+
+def test_process_truncates_task_id():
+    """Only the first 8 chars of the task UUID are rendered."""
+    adapter = _adapter({"task": "54e3ea08-383a-4d96-9fc9-51948c8130b6"})
+    msg, _ = adapter.process("hello", {})
+    assert msg == "T.54e3ea08 hello"
+
+
+def test_process_without_task_uses_placeholder():
+    adapter = _adapter({"marker": "DOWNLOAD"})
+    msg, _ = adapter.process("hello", {})
+    assert msg == "T.000000 DOWNLOAD hello"
+
+
+def test_process_all_fragments():
+    adapter = _adapter(
+        {
+            "task": "abcdef0123456789",
+            "marker": "LOAD",
+            "target": "Mpro",
+            "tas": "lb12345-1",
+            "username": "alice",
+        }
+    )
+    msg, _ = adapter.process("go", {})
+    assert msg == "T.abcdef01 LOAD t(Mpro) tas(lb12345-1) u(alice) go"
+
+
+def test_process_blank_username_is_anon():
+    adapter = _adapter({"task": "abcdef0123456789", "username": ""})
+    msg, _ = adapter.process("go", {})
+    assert msg == "T.abcdef01 u(|anon|) go"
+
+
+def test_process_passes_kwargs_through():
+    adapter = _adapter({"task": "abcdef0123456789"})
+    _, kwargs = adapter.process("go", {"stacklevel": 2})
+    assert kwargs == {"stacklevel": 2}

--- a/viewer/tests/test_permissions.py
+++ b/viewer/tests/test_permissions.py
@@ -1,0 +1,84 @@
+"""Tests for ``viewer.permissions.IsObjectProposalMember`` (issue #991).
+
+The permission grants object-level write access only to users who are members of
+one of the object's proposals. It resolves the object's proposals via the view's
+``filter_permissions`` attribute (a relation path like ``project``). These tests
+drive it with a real ``Target`` object and a ``RequestFactory`` request, using
+``make_project(members=...)`` to control membership - no external service.
+"""
+# pylint: disable=redefined-outer-name
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+from rest_framework.exceptions import PermissionDenied
+
+from viewer.permissions import IsObjectProposalMember
+
+
+class _View:
+    """A stand-in DRF view exposing only what the permission reads."""
+
+    def __init__(self, filter_permissions="project"):
+        self.filter_permissions = filter_permissions
+
+
+@pytest.fixture
+def request_factory():
+    return RequestFactory()
+
+
+def test_member_is_granted(
+    request_factory, make_user, make_project, make_target, settings
+):
+    settings.TA_AUTH_SERVICE = ""
+    user = make_user("member")
+    target = make_target(make_project("lb12345-1", members=[user]))
+
+    request = request_factory.get("/")
+    request.user = user
+
+    permission = IsObjectProposalMember()
+    assert permission.has_object_permission(request, _View(), target) is True
+
+
+def test_non_member_is_denied(
+    request_factory, make_user, make_project, make_target, settings
+):
+    settings.TA_AUTH_SERVICE = ""
+    member = make_user("member")
+    outsider = make_user("outsider")
+    target = make_target(make_project("lb12345-1", members=[member]))
+
+    request = request_factory.get("/")
+    request.user = outsider
+
+    permission = IsObjectProposalMember()
+    with pytest.raises(PermissionDenied):
+        permission.has_object_permission(request, _View(), target)
+
+
+def test_unauthenticated_user_is_denied(request_factory, make_project, make_target):
+    target = make_target(make_project("lb12345-1"))
+
+    request = request_factory.get("/")
+    request.user = AnonymousUser()
+
+    permission = IsObjectProposalMember()
+    assert permission.has_object_permission(request, _View(), target) is False
+
+
+def test_view_without_filter_permissions_raises(
+    request_factory, make_user, make_project, make_target
+):
+    user = make_user("member")
+    target = make_target(make_project("lb12345-1", members=[user]))
+
+    request = request_factory.get("/")
+    request.user = user
+
+    class _BadView:
+        pass
+
+    permission = IsObjectProposalMember()
+    with pytest.raises(AttributeError):
+        permission.has_object_permission(request, _BadView(), target)

--- a/viewer/tests/test_sdf_check.py
+++ b/viewer/tests/test_sdf_check.py
@@ -1,0 +1,143 @@
+"""Tests for the compound-set SDF validators in ``viewer.sdf_check`` (#991).
+
+These validators build a ``validate_dict`` of parallel ``molecule_name`` /
+``field`` / ``warning_string`` lists, appending a record for every problem
+found. The tests construct RDKit mols from SMILES (with properties set via
+``SetProp``) - no database or filesystem is involved.
+"""
+import pytest
+from rdkit import Chem
+
+from viewer import sdf_check
+
+
+def empty_validate_dict():
+    return {"molecule_name": [], "field": [], "warning_string": []}
+
+
+def make_mol(name="mol1", props=None):
+    mol = Chem.MolFromSmiles("CCO")
+    mol.SetProp("_Name", name)
+    for key, value in (props or {}).items():
+        mol.SetProp(key, value)
+    return mol
+
+
+def warnings_count(validate_dict):
+    return len(validate_dict["warning_string"])
+
+
+def test_add_warning_appends_parallel_lists():
+    vd = empty_validate_dict()
+    result = sdf_check.add_warning("mol1", "field1", "boom", vd)
+    assert result["molecule_name"] == ["mol1"]
+    assert result["field"] == ["field1"]
+    assert result["warning_string"] == ["boom"]
+
+
+def test_check_sdf_illegal_filename_warns():
+    vd = sdf_check.check_sdf("compound-set_thing.txt", empty_validate_dict())
+    assert warnings_count(vd) == 1
+    assert vd["field"] == ["_File_name"]
+
+
+def test_check_sdf_valid_filename_no_warning():
+    vd = sdf_check.check_sdf("compound-set_thing.sdf", empty_validate_dict())
+    assert warnings_count(vd) == 0
+
+
+@pytest.mark.parametrize("name", ["good-name_1.0", "abc.def"])
+def test_check_name_characters_legal(name):
+    vd = sdf_check.check_name_characters(name, empty_validate_dict())
+    assert warnings_count(vd) == 0
+
+
+def test_check_name_characters_illegal():
+    vd = sdf_check.check_name_characters("bad name!", empty_validate_dict())
+    # space and '!' are both illegal -> two warnings
+    assert warnings_count(vd) == 2
+
+
+def test_check_url_valid_returns_none():
+    assert sdf_check.check_url("https://example.com") is None
+
+
+def test_check_url_invalid_returns_false():
+    assert sdf_check.check_url("not a url") is False
+
+
+def test_missing_field_check_present():
+    mol = make_mol(props={"ref_mols": "x0107"})
+    vd = sdf_check.missing_field_check(mol, "ref_mols", empty_validate_dict())
+    assert warnings_count(vd) == 0
+
+
+def test_missing_field_check_absent():
+    mol = make_mol()
+    vd = sdf_check.missing_field_check(mol, "ref_mols", empty_validate_dict())
+    assert warnings_count(vd) == 1
+    assert vd["field"] == ["ref_mols"]
+
+
+def test_check_blank_prop_warns_on_empty_and_bad_url():
+    mol = make_mol(props={"submitter_name": "", "ref_url": "not a url"})
+    vd = sdf_check.check_blank_prop(mol, empty_validate_dict())
+    # empty submitter_name -> 1 warning; bad ref_url -> 1 warning
+    assert warnings_count(vd) == 2
+
+
+def test_check_blank_prop_ignores_listed_props():
+    mol = make_mol(props={"ref_pdb": ""})
+    vd = sdf_check.check_blank_prop(mol, empty_validate_dict())
+    assert warnings_count(vd) == 0
+
+
+def test_check_mol_props_missing_ref_pdb_and_lhs_pdb():
+    mol = make_mol(props={"ref_mols": "x0107"})
+    vd = sdf_check.check_mol_props(mol, empty_validate_dict())
+    # ref_mols present, but neither ref_pdb nor lhs_pdb -> 1 warning
+    assert warnings_count(vd) == 1
+    assert vd["field"] == ["ref_pdb/lhs_pdb"]
+
+
+def test_check_mol_props_ref_pdb_satisfies():
+    mol = make_mol(props={"ref_mols": "x0107", "ref_pdb": "x0107.pdb"})
+    vd = sdf_check.check_mol_props(mol, empty_validate_dict())
+    assert warnings_count(vd) == 0
+
+
+def test_check_mol_props_lhs_pdb_satisfies():
+    mol = make_mol(props={"ref_mols": "x0107", "lhs_pdb": "x0107.pdb"})
+    vd = sdf_check.check_mol_props(mol, empty_validate_dict())
+    assert warnings_count(vd) == 0
+
+
+def test_check_ver_name_matches():
+    mol = make_mol(name="ver_1.2")
+    vd = sdf_check.check_ver_name(mol, "ver_1.2", empty_validate_dict())
+    assert warnings_count(vd) == 0
+
+
+def test_check_ver_name_mismatch():
+    mol = make_mol(name="ver_1.0")
+    vd = sdf_check.check_ver_name(mol, "ver_1.2", empty_validate_dict())
+    assert warnings_count(vd) == 1
+
+
+def test_check_compound_set_no_generation_date():
+    mol = make_mol()
+    vd = sdf_check.check_compound_set(mol, empty_validate_dict())
+    assert warnings_count(vd) == 1
+    assert "no generation_date" in vd["warning_string"][0]
+
+
+def test_check_compound_set_malformed_generation_date():
+    mol = make_mol(props={"generation_date": "2020/01/01"})
+    vd = sdf_check.check_compound_set(mol, empty_validate_dict())
+    assert warnings_count(vd) == 1
+
+
+def test_check_compound_set_valid_generation_date():
+    mol = make_mol(props={"generation_date": "2020-01-01"})
+    vd = sdf_check.check_compound_set(mol, empty_validate_dict())
+    assert warnings_count(vd) == 0

--- a/viewer/tests/test_security_helpers.py
+++ b/viewer/tests/test_security_helpers.py
@@ -1,0 +1,49 @@
+"""Tests for the membership helpers on ``ISPyBSafeQuerySet`` (issue #991).
+
+``user_is_member_of_target`` and ``user_is_member_of_any_given_proposals`` both
+sit on top of ``get_proposals_for_user``. With ``TA_AUTH_SERVICE`` unset the
+proposal set is derived from the Django ``Project.user_id`` membership M2M, so
+``make_project(members=...)`` is enough to drive both the allow and deny paths
+without any external access-control service.
+"""
+from api.security import ISPyBSafeQuerySet
+
+
+def test_user_is_member_of_target_true(make_user, make_project, make_target, settings):
+    settings.TA_AUTH_SERVICE = ""
+    user = make_user("member")
+    project = make_project("lb12345-1", members=[user])
+    target = make_target(project)
+
+    assert ISPyBSafeQuerySet().user_is_member_of_target(user, target) is True
+
+
+def test_user_is_member_of_target_false(make_user, make_project, make_target, settings):
+    settings.TA_AUTH_SERVICE = ""
+    member = make_user("member")
+    outsider = make_user("outsider")
+    project = make_project("lb12345-1", members=[member])
+    target = make_target(project)
+
+    assert ISPyBSafeQuerySet().user_is_member_of_target(outsider, target) is False
+
+
+def test_user_is_member_of_any_given_proposals_true(make_user, make_project, settings):
+    settings.TA_AUTH_SERVICE = ""
+    user = make_user("member")
+    make_project("lb12345-1", members=[user])
+
+    safe_qs = ISPyBSafeQuerySet()
+    assert (
+        safe_qs.user_is_member_of_any_given_proposals(user, ["lb99999-1", "lb12345-1"])
+        is True
+    )
+
+
+def test_user_is_member_of_any_given_proposals_false(make_user, make_project, settings):
+    settings.TA_AUTH_SERVICE = ""
+    user = make_user("member")
+    make_project("lb12345-1", members=[user])
+
+    safe_qs = ISPyBSafeQuerySet()
+    assert safe_qs.user_is_member_of_any_given_proposals(user, ["lb99999-1"]) is False

--- a/viewer/tests/test_viewer_utils_pure.py
+++ b/viewer/tests/test_viewer_utils_pure.py
@@ -1,0 +1,154 @@
+"""Pure-function tests for the small helpers in ``viewer.utils`` (issue #991).
+
+These complement ``test_utils.py`` (which covers the filesystem/SDF helpers)
+by exercising the string/identifier helpers, the ``alphanumerator`` generator,
+``flatten_dict`` and the filesystem-only ``calculate_sha256`` /
+``sanitize_directory_name``. None of these need a database; the few that touch
+disk use ``tmp_path``.
+"""
+import itertools
+
+import pytest
+
+from viewer.utils import (
+    alphanumerator,
+    calculate_sha256,
+    clean_object_id,
+    flatten_dict,
+    flattened_inchi_from_smiles,
+    longcode_from_tag,
+    sanitize_directory_name,
+    strip_exp_code,
+    strip_version,
+)
+
+
+def test_alphanumerator_from_empty_start():
+    """With no start the generator yields a, b, c ... from the beginning."""
+    gen = alphanumerator()
+    assert list(itertools.islice(gen, 3)) == ["a", "b", "c"]
+
+
+def test_alphanumerator_drop_first_default():
+    """Default drop_first=True returns the value *after* start_from."""
+    gen = alphanumerator(start_from="a")
+    assert list(itertools.islice(gen, 3)) == ["b", "c", "d"]
+
+
+def test_alphanumerator_keep_first():
+    """drop_first=False makes start_from itself the first value yielded."""
+    gen = alphanumerator(start_from="a", drop_first=False)
+    assert list(itertools.islice(gen, 3)) == ["a", "b", "c"]
+
+
+def test_alphanumerator_is_case_insensitive():
+    """start_from is lower-cased before matching."""
+    gen = alphanumerator(start_from="B", drop_first=False)
+    assert next(gen) == "b"
+
+
+def test_alphanumerator_rolls_over_to_two_letters():
+    """After 'z' the generator continues with two-letter words."""
+    gen = alphanumerator(start_from="z")
+    assert next(gen) == "aa"
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        # The '-x' anchored form: only the tail after '-x' is rewritten.
+        ("Mpro-x0107+A+1+1", "Mpro-x0107/A/1/1"),
+        ("Mpro-x0107_A_1_1", "Mpro-x0107/A/1/1"),
+        # No '-x' anchor: '+' and '_' are rewritten across the whole string.
+        ("foo+bar_baz", "foo/bar/baz"),
+        # Nothing to replace.
+        ("plain", "plain"),
+    ],
+)
+def test_clean_object_id(name, expected):
+    assert clean_object_id(name) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("XX01ZVNS2B-x0673/B/501/1", ("XX01ZVNS2B-x0673/B/501", 1)),
+        ("a/b/12", ("a/b", 12)),
+    ],
+)
+def test_strip_version(value, expected):
+    assert strip_version(value) == expected
+
+
+def test_strip_version_custom_separator():
+    assert strip_version("a-b-7", separator="-") == ("a-b", 7)
+
+
+def test_longcode_from_tag():
+    assert longcode_from_tag("XX-x0673/B/501/1") == "XX-x0673_B_501_v1"
+
+
+def test_longcode_from_tag_custom_separator():
+    assert longcode_from_tag("a-b-2", separator="-") == "a_b_v2"
+
+
+def test_strip_exp_code():
+    """The chunk after the first '-<letter>' marker is returned."""
+    assert strip_exp_code("Mpro-x0107") == "0107"
+
+
+def test_strip_exp_code_non_standard_raises():
+    """A code without a '-<letter>' marker raises a ValueError."""
+    with pytest.raises(ValueError, match="Non-standard experiment code"):
+        strip_exp_code("plaincode")
+
+
+def test_flatten_dict_shallow():
+    """A flat dict (values are not dicts-of-dicts) is yielded unchanged."""
+    result = dict(flatten_dict({"a": {"x": 1}, "b": {"y": 2}}))
+    assert result == {"a": {"x": 1}, "b": {"y": 2}}
+
+
+def test_flatten_dict_nested_to_depth():
+    """Nested dicts are flattened: a key path of length n yields an
+    (n+1)-tuple ending in the leaf value."""
+    nested = {"a": {"b": {"x": 1}, "c": {"y": 2}}}
+    result = list(flatten_dict(nested, depth=2))
+    assert result == [("a", "b", {"x": 1}), ("a", "c", {"y": 2})]
+
+
+def test_flatten_dict_skips_non_dict_values():
+    """Values that are not dicts (no .values()) are skipped, not raised."""
+    assert dict(flatten_dict({"a": 1, "b": "text"})) == {}
+
+
+def test_calculate_sha256(tmp_path):
+    """The digest matches the known SHA-256 of the file's bytes."""
+    import hashlib
+
+    target = tmp_path / "blob.bin"
+    payload = b"fragalysis" * 1000
+    target.write_bytes(payload)
+    assert calculate_sha256(target) == hashlib.sha256(payload).hexdigest()
+
+
+def test_sanitize_directory_name_replaces_illegal_chars():
+    assert sanitize_directory_name("My Target!/v2") == "My_Target_v2"
+
+
+def test_sanitize_directory_name_collapses_underscores():
+    assert sanitize_directory_name("a   b") == "a_b"
+
+
+def test_sanitize_directory_name_unique_within_path(tmp_path):
+    """A name colliding with an existing dir gets a numeric suffix."""
+    (tmp_path / "target").mkdir()
+    assert sanitize_directory_name("target", path=tmp_path) == "target_2"
+
+
+def test_flattened_inchi_from_smiles_drops_stereochemistry():
+    """Two enantiomers flatten to the same stereo-free InChI."""
+    left = flattened_inchi_from_smiles("C[C@H](N)C(=O)O")
+    right = flattened_inchi_from_smiles("C[C@@H](N)C(=O)O")
+    assert left == right
+    assert left.startswith("InChI=")


### PR DESCRIPTION
Fixes #991

## What

Phase 4 of the test-coverage ratchet (continuing #985/#986/#987). Adds
lightly-mocked / pure-function unit tests for ~35 previously untested helpers
that need **no real data**, then raises the coverage floor to lock in the gain.

- `fail_under` raised **39 → 40** in `pyproject.toml` (measured total **40.96%**).

## New test modules (under `viewer/tests/`)

All live under `viewer/tests/` — the suite's single `testpaths` root — even
those exercising `api`/`hypothesis` code, matching the existing convention
(`test_api_utils.py`).

| File | Covers |
| --- | --- |
| `test_viewer_utils_pure.py` | `alphanumerator` (drop_first/rollover), `clean_object_id`, `strip_version`, `longcode_from_tag`, `strip_exp_code` (+ `ValueError`), `flatten_dict`, `calculate_sha256`, `sanitize_directory_name`, `flattened_inchi_from_smiles` |
| `test_api_utils_pure.py` | `parse_bool` (+ `ValueError`), `parse_vectors` (+ `ValueError`), `calc_dims`, `calc_bounds` |
| `test_logger_adapters.py` | `TaskLoggerAdapter.process` — each optional fragment incl. blank-username → `u(\|anon\|)` |
| `test_sdf_check.py` | compound-set SDF validators (`add_warning`, `check_sdf`, `check_name_characters`, `check_url`, `missing_field_check`, `check_blank_prop`, `check_mol_props` ref_pdb/lhs_pdb branch, `check_ver_name`, `check_compound_set`) |
| `test_hypothesis_definitions.py` | `IntTypes.get_int_conv`, `VectTypes.translate_vect_types`, defaults |
| `test_assay_data.py` | `process_float_value` / `process_int_value` (modifier + unparseable branches) / `process_text_value` / `get_unit` |
| `test_security_helpers.py` | `ISPyBSafeQuerySet.user_is_member_of_target`, `user_is_member_of_any_given_proposals` |
| `test_permissions.py` | `IsObjectProposalMember.has_object_permission` (member, non-member, anon, missing `filter_permissions`) |
| `test_cache.py` | `clear_view_cache` (no-op / non-Redis clear / Redis SCAN+DELETE patterns), `clear_all_view_caches` |

## Note: one target deliberately skipped

`api.utils._transparentsvg` was on the issue's target list but is **not** tested:
it is dead code (defined but never called) and carries a latent `str + bytes`
bug (`'...' + ET.tostring(tree)`), so exercising it would require fixing
unrelated code. Flagging here rather than scope-creeping the fix into this PR.

## Verification

- All new tests pass; full suite **333 passed, 1 skipped**.
- Coverage gate passes at the new floor: *"Required test coverage of 40.0%
  reached. Total coverage: 40.96%"*.
- `pre-commit run --files <new files>` passes (black/isort/mypy/pylint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
