### PR TITLE
ci: visualise coverage in GitHub CI

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -30,6 +30,8 @@ on:
     branches-ignore:
     - 'staging'
     - 'production'
+    # Orphan branch holding only the coverage-badge JSON (see build-staging).
+    - 'coverage-badge'
     tags-ignore:
     - '**'
 
@@ -122,6 +124,18 @@ jobs:
       # backend image is not needed. DB connection defaults live in
       # tests/test_settings.py.
       run: poetry run pytest
+    - name: Coverage summary
+      # Render the coverage table on the run's summary page. The real gate is
+      # pytest itself (fail_under in pyproject); '|| true' stops this
+      # display-only step from re-failing on a low total, and '!cancelled()'
+      # shows the table even when pytest failed.
+      if: ${{ !cancelled() }}
+      run: |
+        {
+          echo '## Coverage'
+          echo
+          poetry run coverage report --format=markdown
+        } >> "$GITHUB_STEP_SUMMARY" || true
     - name: Docker build
       uses: docker/build-push-action@v7
       with:

--- a/.github/workflows/build-production.yaml
+++ b/.github/workflows/build-production.yaml
@@ -166,6 +166,18 @@ jobs:
       # backend image is not needed. DB connection defaults live in
       # tests/test_settings.py.
       run: poetry run pytest
+    - name: Coverage summary
+      # Render the coverage table on the run's summary page. The real gate is
+      # pytest itself (fail_under in pyproject); '|| true' stops this
+      # display-only step from re-failing on a low total, and '!cancelled()'
+      # shows the table even when pytest failed.
+      if: ${{ !cancelled() }}
+      run: |
+        {
+          echo '## Coverage'
+          echo
+          poetry run coverage report --format=markdown
+        } >> "$GITHUB_STEP_SUMMARY" || true
     - name: Build
       uses: docker/build-push-action@v7
       with:

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -77,6 +77,10 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # 'contents: write' lets the coverage-badge step force-push the orphan
+    # 'coverage-badge' branch; checkout/build only need read.
+    permissions:
+      contents: write
     outputs:
       push: ${{ steps.vars.outputs.push }}
       tag: ${{ steps.vars.outputs.tag }}
@@ -188,6 +192,50 @@ jobs:
       # backend image is not needed. DB connection defaults live in
       # tests/test_settings.py.
       run: poetry run pytest
+    - name: Coverage summary
+      # Render the coverage table on the run's summary page. The real gate is
+      # pytest itself (fail_under in pyproject); '|| true' stops this
+      # display-only step from re-failing on a low total, and '!cancelled()'
+      # shows the table even when pytest failed.
+      if: ${{ !cancelled() }}
+      run: |
+        {
+          echo '## Coverage'
+          echo
+          poetry run coverage report --format=markdown
+        } >> "$GITHUB_STEP_SUMMARY" || true
+    - name: Update coverage badge
+      # Publish a shields.io endpoint JSON to the orphan 'coverage-badge'
+      # branch so the README badge tracks staging's coverage. Force-pushed as a
+      # single commit; '[skip ci]' stops it triggering build-dev.
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/staging'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        poetry run coverage json -o coverage.json
+        PCT=$(python -c "import json; print(round(json.load(open('coverage.json'))['totals']['percent_covered']))")
+        if [ "${PCT}" -ge 80 ]; then
+          COLOR=brightgreen
+        elif [ "${PCT}" -ge 60 ]; then
+          COLOR=green
+        elif [ "${PCT}" -ge 40 ]; then
+          COLOR=yellow
+        else
+          COLOR=red
+        fi
+        WORK=$(mktemp -d)
+        printf '{"schemaVersion":1,"label":"coverage","message":"%s%%","color":"%s"}\n' \
+          "${PCT}" "${COLOR}" > "${WORK}/coverage.json"
+        git -C "${WORK}" init -q
+        git -C "${WORK}" checkout -q -b coverage-badge
+        git -C "${WORK}" add coverage.json
+        git -C "${WORK}" \
+          -c user.name="github-actions[bot]" \
+          -c user.email="github-actions[bot]@users.noreply.github.com" \
+          commit -q -m "ci: update coverage badge [skip ci]"
+        git -C "${WORK}" push -q -f \
+          "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" \
+          coverage-badge
     - name: Docker build
       uses: docker/build-push-action@v7
       with:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![build dev](https://github.com/xchem/fragalysis-backend/actions/workflows/build-dev.yaml/badge.svg)](https://github.com/xchem/fragalysis-backend/actions/workflows/build-dev.yaml)
 [![build staging](https://github.com/xchem/fragalysis-backend/actions/workflows/build-staging.yaml/badge.svg)](https://github.com/xchem/fragalysis-backend/actions/workflows/build-staging.yaml)
 [![build production](https://github.com/xchem/fragalysis-backend/actions/workflows/build-production.yaml/badge.svg)](https://github.com/xchem/fragalysis-backend/actions/workflows/build-production.yaml)
+[![coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/xchem/fragalysis-backend/coverage-badge/coverage.json)](https://github.com/xchem/fragalysis-backend/actions/workflows/build-staging.yaml)
 
 [![License](http://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat)](https://github.com/xchem/fragalysis-backend/blob/master/LICENSE.txt)
 


### PR DESCRIPTION
## What

Surface the coverage pytest already computes (the `--cov` run with the `fail_under` ratchet) directly in GitHub — no external service, no new secret.

### Coverage summary table
All three build workflows (`build-dev`, `build-staging`, `build-production`) append `coverage report --format=markdown` to `$GITHUB_STEP_SUMMARY`, so a **Coverage** table (Stmts / Miss / Cover + TOTAL) renders on every workflow-run page.
- `if: !cancelled()` — shown even when pytest fails the `fail_under=40` gate.
- `|| true` — display only; pytest stays the gate, this step never fails the run.

### README badge
On a passing push to `staging`, `build-staging` derives the total from `coverage json`, picks a colour (≥80 brightgreen / ≥60 green / ≥40 yellow / else red), and force-pushes a shields.io endpoint `coverage.json` as a single commit to the orphan `coverage-badge` branch. README references it via a shields endpoint URL.
- Uses the built-in `GITHUB_TOKEN` (new `permissions: contents: write` on the staging build job); no new secret.
- `success() &&` guard — only updates when tests pass.
- Commit carries `[skip ci]` and `coverage-badge` is added to `build-dev`'s `branches-ignore`, so the push can't trigger a build loop.

## Notes
- The badge shows "invalid" until the first post-merge `staging` build creates the `coverage-badge` branch.
- Depends on the org allowing the default token to create a branch; a branch-protection rule blocking all new-branch pushes would need an exception.
- Verified: the three workflows parse as YAML, and `coverage report --format=markdown` + the `coverage json` percent extraction were dry-run locally (coverage 7.14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)