### PR TITLE
ci: upload HTML coverage report as an artifact

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -136,6 +136,16 @@ jobs:
           echo
           poetry run coverage report --format=markdown
         } >> "$GITHUB_STEP_SUMMARY" || true
+    - name: Upload HTML coverage report
+      # Browsable, line-by-line report (pytest's --cov-report=html) showing
+      # exactly which lines are untested. Uploaded even when pytest fails the
+      # gate, so a low total can be investigated.
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-html
+        path: htmlcov/
+        if-no-files-found: ignore
     - name: Docker build
       uses: docker/build-push-action@v7
       with:

--- a/.github/workflows/build-production.yaml
+++ b/.github/workflows/build-production.yaml
@@ -178,6 +178,16 @@ jobs:
           echo
           poetry run coverage report --format=markdown
         } >> "$GITHUB_STEP_SUMMARY" || true
+    - name: Upload HTML coverage report
+      # Browsable, line-by-line report (pytest's --cov-report=html) showing
+      # exactly which lines are untested. Uploaded even when pytest fails the
+      # gate, so a low total can be investigated.
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-html
+        path: htmlcov/
+        if-no-files-found: ignore
     - name: Build
       uses: docker/build-push-action@v7
       with:

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -204,6 +204,16 @@ jobs:
           echo
           poetry run coverage report --format=markdown
         } >> "$GITHUB_STEP_SUMMARY" || true
+    - name: Upload HTML coverage report
+      # Browsable, line-by-line report (pytest's --cov-report=html) showing
+      # exactly which lines are untested. Uploaded even when pytest fails the
+      # gate, so a low total can be investigated.
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-html
+        path: htmlcov/
+        if-no-files-found: ignore
     - name: Update coverage badge
       # Publish a shields.io endpoint JSON to the orphan 'coverage-badge'
       # branch so the README badge tracks staging's coverage. Force-pushed as a


### PR DESCRIPTION
## What

pytest already generates the browsable HTML coverage report (`htmlcov/`, via
`--cov-report=html` in `pyproject.toml`) but it was only ever produced locally.
This uploads it as a build artifact from all three build workflows
(`build-dev`, `build-staging`, `build-production`).

Download **coverage-html** from a run's *Artifacts* section and open
`index.html` to see line-by-line which code is untested.

- `actions/upload-artifact@v4`, artifact name `coverage-html`, path `htmlcov/`.
- `if: !cancelled()` — uploaded even when pytest fails the `fail_under` gate,
  so a drop can be investigated.
- `if-no-files-found: ignore` — no failure if the report is absent.

Follow-up to #993 (coverage summary table + README badge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
