### PR TITLE
fix(1011): default molimg height/width when not supplied

### DIFF
--- a/viewer/serializers.py
+++ b/viewer/serializers.py
@@ -31,6 +31,17 @@ logger = logging.getLogger(__name__)
 _ISPYB_SAFE_QUERY_SET = ISPyBSafeQuerySet()
 
 
+def _int_param(params, name: str, default: int) -> int:
+    """The named query parameter as an int, or `default` if it wasn't supplied.
+
+    Values are read via float() first, so a decimal string (e.g. "125.0") is
+    accepted and truncated. A supplied but unparseable value still raises.
+    """
+    if name not in params:
+        return default
+    return int(float(params[name]))
+
+
 class ValidateProjectMixin:
     """Mixin for serializers to check if user is allowed to create objects.
 
@@ -430,17 +441,19 @@ class ProjectSerializer(serializers.ModelSerializer):
 class MolImageSerializer(serializers.ModelSerializer):
     mol_image = serializers.SerializerMethodField()
 
+    # Image size used when the request doesn't ask for one.
+    DEFAULT_HEIGHT = 125
+    DEFAULT_WIDTH = 125
+
     def get_mol_image(self, obj):
-        request = self.context["request"]
-        params = request.query_params
-        if params:
-            return draw_mol(
-                obj.smiles,
-                height=int(float(params["height"])),
-                width=int(float(params["width"])),
-            )
-        else:
-            return draw_mol(obj.smiles, height=125, width=125)
+        # Size from the query parameters, each defaulting independently - the
+        # request may carry filtering or pagination parameters and no size.
+        params = self.context["request"].query_params
+        return draw_mol(
+            obj.smiles,
+            height=_int_param(params, "height", self.DEFAULT_HEIGHT),
+            width=_int_param(params, "width", self.DEFAULT_WIDTH),
+        )
 
     class Meta:
         model = models.SiteObservation

--- a/viewer/tests/test_molimg_serialization.py
+++ b/viewer/tests/test_molimg_serialization.py
@@ -1,0 +1,81 @@
+"""Regression test for ticket #1011.
+
+``MolImageSerializer.get_mol_image`` sized the image from the request's
+``height``/``width`` query parameters, but guarded that lookup with a bare
+``if params:`` - true whenever *any* parameter is present. A request that
+filters or paginates without asking for a size, e.g. ``/api/molimg/?target=1``,
+therefore raised ``MultiValueDictKeyError: 'height'`` and surfaced as a 500.
+
+Each dimension now falls back to its default independently, so only the
+supplied parameters influence the image.
+"""
+import re
+
+import pytest
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+
+from viewer.models import SiteObservation
+from viewer.serializers import MolImageSerializer
+
+# Any valid SMILES will do; draw_mol() renders it to SVG.
+SMILES = "c1ccccc1"
+
+DEFAULT_HEIGHT = 125
+DEFAULT_WIDTH = 125
+
+
+def _mol_image(**query_params) -> str:
+    """Serialize a SiteObservation's image for a request with these params."""
+    request = Request(APIRequestFactory().get("/api/molimg/", query_params))
+    serializer = MolImageSerializer(context={"request": request})
+    return serializer.get_mol_image(SiteObservation(smiles=SMILES))
+
+
+def _svg_dimensions(svg: str) -> tuple[int, int]:
+    """Pull the (height, width) that RDKit wrote into the SVG element."""
+    height = re.search(r"height=['\"](\d+)px['\"]", svg)
+    width = re.search(r"width=['\"](\d+)px['\"]", svg)
+    assert height and width, f"no dimensions in SVG: {svg[:200]}"
+    return int(height.group(1)), int(width.group(1))
+
+
+def test_get_mol_image_uses_defaults_when_size_params_absent():
+    """A filtering param without height/width renders at the default size."""
+    # Before the fix this raised MultiValueDictKeyError: 'height'.
+    svg = _mol_image(target="1")
+
+    assert _svg_dimensions(svg) == (DEFAULT_HEIGHT, DEFAULT_WIDTH)
+
+
+def test_get_mol_image_uses_defaults_when_no_params_at_all():
+    """The unparameterised request keeps rendering at the default size."""
+    svg = _mol_image()
+
+    assert _svg_dimensions(svg) == (DEFAULT_HEIGHT, DEFAULT_WIDTH)
+
+
+def test_get_mol_image_honours_explicit_size_params():
+    """Supplied height and width are used."""
+    svg = _mol_image(height="200", width="300")
+
+    assert _svg_dimensions(svg) == (200, 300)
+
+
+@pytest.mark.parametrize(
+    "params, expected",
+    [
+        ({"height": "200"}, (200, DEFAULT_WIDTH)),
+        ({"width": "300"}, (DEFAULT_HEIGHT, 300)),
+    ],
+)
+def test_get_mol_image_defaults_the_missing_dimension(params, expected):
+    """One dimension given: the other falls back to its default."""
+    assert _svg_dimensions(_mol_image(**params)) == expected
+
+
+def test_get_mol_image_accepts_float_size_params():
+    """Sizes arriving as floats are truncated to int, as they always were."""
+    svg = _mol_image(height="200.7", width="300.2")
+
+    assert _svg_dimensions(svg) == (200, 300)


### PR DESCRIPTION
Fixes #1011.

## Problem

`/api/molimg/` returns 500 in production. `MolImageSerializer.get_mol_image` sized the image from the request's `height`/`width` query parameters, but guarded that lookup with a bare `if params:`:

```python
params = request.query_params
if params:                                  # true if ANY parameter is present
    return draw_mol(
        obj.smiles,
        height=int(float(params["height"])),  # KeyError when height wasn't one of them
        width=int(float(params["width"])),
    )
else:
    return draw_mol(obj.smiles, height=125, width=125)
```

`MolImgFilter` accepts `target`, `cmpd`, `smiles` and `site_observation_groups`, so `/api/molimg/?target=1` — or plain `?page=2` pagination — makes `params` truthy with no size in it, and the lookup raises `MultiValueDictKeyError: 'height'`. The all-or-nothing guard only ever worked for requests that supplied *both* dimensions or *no* parameters at all.

## Fix

Each dimension is read through a small module-level `_int_param()` helper and defaults independently, so filtering and pagination parameters no longer affect sizing:

```python
params = self.context["request"].query_params
return draw_mol(
    obj.smiles,
    height=_int_param(params, "height", self.DEFAULT_HEIGHT),
    width=_int_param(params, "width", self.DEFAULT_WIDTH),
)
```

The 125×125 defaults become named class attributes rather than repeated literals. Behaviour is otherwise unchanged: values are still read via `float()` so decimal strings are accepted and truncated.

No API contract change — responses that worked before are byte-identical.

## Out of scope (noted, not fixed)

A *supplied but unparseable* size (`?height=abc`) still raises `ValueError` → 500. That is pre-existing behaviour and a different defect; properly it should be a 400 from request validation. Happy to file it separately if you'd like it dealt with.

## Testing

New regression test `viewer/tests/test_molimg_serialization.py`, written first (TDD) — it reproduced the exact production `MultiValueDictKeyError` before the fix. It covers:

- a filtering parameter with no size → defaults (the reported 500);
- no parameters at all → defaults;
- explicit `height`/`width` → honoured;
- only one dimension supplied → the other defaults;
- float-valued sizes → truncated.

Full suite: **350 passed, 1 skipped**. `pre-commit` (isort/black/mypy/pylint) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
